### PR TITLE
Fix crash when receiving struct is different than value.

### DIFF
--- a/internal/decoding/struct.go
+++ b/internal/decoding/struct.go
@@ -38,8 +38,12 @@ func (d *decoder) setStruct(rv reflect.Value, offset int, k reflect.Kind) (int, 
 			if err != nil {
 				return 0, err
 			}
-			rv.Set(reflect.ValueOf(v))
-			return offset, nil
+
+			// Validate that the receptacle is of the right value type.
+			if rv.Type() == reflect.TypeOf(v) {
+				rv.Set(reflect.ValueOf(v))
+				return offset, nil
+			}
 		}
 	}
 


### PR DESCRIPTION
When adding ext coders, sometimes the initial value before encoding is a struct and the final type is a type (like int).
Ex. sql.NullInt32 (which is a struct with Int32 as int, and Valid as bool) that we want to output as either a null or an int. When reading it back, the receptacle will be the stuct, not an int. That leads to crashes. Therefore, before trying to feed the receptacle, a check if it matches the value will prevent this.