### PR TITLE
Update version to v2.0.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,19 +1,19 @@
 # MessagePack for Golang
 
 [![Go Reference](https://pkg.go.dev/badge/github.com/shamaton/msgpack.svg)](https://pkg.go.dev/github.com/shamaton/msgpack)
-[![Build Status](https://travis-ci.org/shamaton/msgpack.svg?branch=master)](https://travis-ci.org/shamaton/msgpack)
-[![Coverage Status](https://coveralls.io/repos/github/shamaton/msgpack/badge.svg)](https://coveralls.io/github/shamaton/msgpack)
+![test](https://github.com/shamaton/msgpack/workflows/test/badge.svg)
 [![Go Report Card](https://goreportcard.com/badge/github.com/shamaton/msgpack)](https://goreportcard.com/report/github.com/shamaton/msgpack)
+[![codecov](https://codecov.io/gh/shamaton/msgpack/branch/master/graph/badge.svg?token=9PD2JUK5V3)](https://codecov.io/gh/shamaton/msgpack)
 [![FOSSA Status](https://app.fossa.com/api/projects/git%2Bgithub.com%2Fshamaton%2Fmsgpack.svg?type=shield)](https://app.fossa.com/projects/git%2Bgithub.com%2Fshamaton%2Fmsgpack?ref=badge_shield)
 
 ## Features
 * Supported types : primitive / array / slice / struct / map / interface{} and time.Time
 * Renaming fields via `msgpack:"field_name"`
-* Omitting fields via `msgpack:"-"` or `msgpack:"ignore"`
+* Omitting fields via `msgpack:"-"`
 * Supports extend encoder / decoder
 * Can also Encoding / Decoding struct as array
 
-This package require more than golang version **1.9**
+This package require more than golang version **1.13**
 
 ## Installation
 ```sh
@@ -74,6 +74,3 @@ BenchmarkCompareDecodeGob-4                        36434             34308 ns/op
 ## License
 
 This library is under the MIT License.
-
-
-[![FOSSA Status](https://app.fossa.com/api/projects/git%2Bgithub.com%2Fshamaton%2Fmsgpack.svg?type=large)](https://app.fossa.com/projects/git%2Bgithub.com%2Fshamaton%2Fmsgpack?ref=badge_large)

--- a/decode.go
+++ b/decode.go
@@ -13,13 +13,3 @@ func UnmarshalAsMap(data []byte, v interface{}) error {
 func UnmarshalAsArray(data []byte, v interface{}) error {
 	return decoding.Decode(data, v, true)
 }
-
-// Deprecated: Use UnmarshalAsMap, this method will be deleted.
-func DecodeStructAsMap(data []byte, v interface{}) error {
-	return UnmarshalAsMap(data, v)
-}
-
-// Deprecated: Use UnmarshalAsArray, this method will be deleted.
-func DecodeStructAsArray(data []byte, v interface{}) error {
-	return UnmarshalAsArray(data, v)
-}

--- a/decode.go
+++ b/decode.go
@@ -1,6 +1,6 @@
 package msgpack
 
-import "github.com/shamaton/msgpack/internal/decoding"
+import "github.com/shamaton/msgpack/v2/internal/decoding"
 
 // UnmarshalAsMap decodes data that is encoded as map format.
 // This is the same thing that StructAsArray sets false.

--- a/encode.go
+++ b/encode.go
@@ -10,18 +10,8 @@ func MarshalAsMap(v interface{}) ([]byte, error) {
 	return encoding.Encode(v, false)
 }
 
-// EncodeStructAsArray encodes data as array format.
+// MarshalAsArray encodes data as array format.
 // This is the same thing that StructAsArray sets true.
 func MarshalAsArray(v interface{}) ([]byte, error) {
 	return encoding.Encode(v, true)
-}
-
-// Deprecated: Use MarshalAsMap, this method will be deleted.
-func EncodeStructAsMap(v interface{}) ([]byte, error) {
-	return MarshalAsMap(v)
-}
-
-// Deprecated: Use MarshalAsArray, this method will be deleted.
-func EncodeStructAsArray(v interface{}) ([]byte, error) {
-	return MarshalAsArray(v)
 }

--- a/encode.go
+++ b/encode.go
@@ -1,7 +1,7 @@
 package msgpack
 
 import (
-	"github.com/shamaton/msgpack/internal/encoding"
+	"github.com/shamaton/msgpack/v2/internal/encoding"
 )
 
 // MarshalAsMap encodes data as map format.

--- a/ext/decode.go
+++ b/ext/decode.go
@@ -3,7 +3,7 @@ package ext
 import (
 	"reflect"
 
-	"github.com/shamaton/msgpack/def"
+	"github.com/shamaton/msgpack/v2/def"
 )
 
 type Decoder interface {

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,3 @@
+module github.com/shamaton/msgpack/v2
+
+go 1.15

--- a/internal/common/common.go
+++ b/internal/common/common.go
@@ -10,7 +10,7 @@ type Common struct {
 func (c *Common) CheckField(field reflect.StructField) (bool, string) {
 	// A to Z
 	if c.isPublic(field.Name) {
-		if tag := field.Tag.Get("msgpack"); tag == "ignore" || tag == "-" {
+		if tag := field.Tag.Get("msgpack"); tag == "-" {
 			return false, ""
 		} else if len(tag) > 0 {
 			return true, tag

--- a/internal/decoding/bin.go
+++ b/internal/decoding/bin.go
@@ -5,7 +5,7 @@ import (
 	"reflect"
 	"unsafe"
 
-	"github.com/shamaton/msgpack/def"
+	"github.com/shamaton/msgpack/v2/def"
 )
 
 func (d *decoder) isCodeBin(v byte) bool {

--- a/internal/decoding/bool.go
+++ b/internal/decoding/bool.go
@@ -3,7 +3,7 @@ package decoding
 import (
 	"reflect"
 
-	"github.com/shamaton/msgpack/def"
+	"github.com/shamaton/msgpack/v2/def"
 )
 
 func (d *decoder) asBool(offset int, k reflect.Kind) (bool, int, error) {

--- a/internal/decoding/complex.go
+++ b/internal/decoding/complex.go
@@ -6,7 +6,7 @@ import (
 	"math"
 	"reflect"
 
-	"github.com/shamaton/msgpack/def"
+	"github.com/shamaton/msgpack/v2/def"
 )
 
 func (d *decoder) asComplex64(offset int, k reflect.Kind) (complex64, int, error) {

--- a/internal/decoding/decoding.go
+++ b/internal/decoding/decoding.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"reflect"
 
-	"github.com/shamaton/msgpack/internal/common"
+	"github.com/shamaton/msgpack/v2/internal/common"
 )
 
 type decoder struct {

--- a/internal/decoding/ext.go
+++ b/internal/decoding/ext.go
@@ -1,8 +1,8 @@
 package decoding
 
 import (
-	"github.com/shamaton/msgpack/ext"
-	"github.com/shamaton/msgpack/time"
+	"github.com/shamaton/msgpack/v2/ext"
+	"github.com/shamaton/msgpack/v2/time"
 )
 
 var extCoderMap = map[int8]ext.Decoder{time.Decoder.Code(): time.Decoder}

--- a/internal/decoding/float.go
+++ b/internal/decoding/float.go
@@ -5,7 +5,7 @@ import (
 	"math"
 	"reflect"
 
-	"github.com/shamaton/msgpack/def"
+	"github.com/shamaton/msgpack/v2/def"
 )
 
 func (d *decoder) asFloat32(offset int, k reflect.Kind) (float32, int, error) {

--- a/internal/decoding/int.go
+++ b/internal/decoding/int.go
@@ -4,7 +4,7 @@ import (
 	"encoding/binary"
 	"reflect"
 
-	"github.com/shamaton/msgpack/def"
+	"github.com/shamaton/msgpack/v2/def"
 )
 
 func (d *decoder) isPositiveFixNum(v byte) bool {

--- a/internal/decoding/interface.go
+++ b/internal/decoding/interface.go
@@ -3,7 +3,7 @@ package decoding
 import (
 	"reflect"
 
-	"github.com/shamaton/msgpack/def"
+	"github.com/shamaton/msgpack/v2/def"
 )
 
 func (d *decoder) asInterface(offset int, k reflect.Kind) (interface{}, int, error) {

--- a/internal/decoding/map.go
+++ b/internal/decoding/map.go
@@ -4,7 +4,7 @@ import (
 	"encoding/binary"
 	"reflect"
 
-	"github.com/shamaton/msgpack/def"
+	"github.com/shamaton/msgpack/v2/def"
 )
 
 var (

--- a/internal/decoding/nil.go
+++ b/internal/decoding/nil.go
@@ -1,6 +1,6 @@
 package decoding
 
-import "github.com/shamaton/msgpack/def"
+import "github.com/shamaton/msgpack/v2/def"
 
 func (d *decoder) isCodeNil(v byte) bool {
 	return def.Nil == v

--- a/internal/decoding/read.go
+++ b/internal/decoding/read.go
@@ -1,7 +1,7 @@
 package decoding
 
 import (
-	"github.com/shamaton/msgpack/def"
+	"github.com/shamaton/msgpack/v2/def"
 )
 
 func (d *decoder) readSize1(index int) (byte, int) {

--- a/internal/decoding/slice.go
+++ b/internal/decoding/slice.go
@@ -4,7 +4,7 @@ import (
 	"encoding/binary"
 	"reflect"
 
-	"github.com/shamaton/msgpack/def"
+	"github.com/shamaton/msgpack/v2/def"
 )
 
 var (

--- a/internal/decoding/string.go
+++ b/internal/decoding/string.go
@@ -5,7 +5,7 @@ import (
 	"reflect"
 	"unsafe"
 
-	"github.com/shamaton/msgpack/def"
+	"github.com/shamaton/msgpack/v2/def"
 )
 
 var emptyString = ""

--- a/internal/decoding/struct.go
+++ b/internal/decoding/struct.go
@@ -5,7 +5,7 @@ import (
 	"reflect"
 	"sync"
 
-	"github.com/shamaton/msgpack/def"
+	"github.com/shamaton/msgpack/v2/def"
 )
 
 type structCacheTypeMap struct {

--- a/internal/decoding/uint.go
+++ b/internal/decoding/uint.go
@@ -4,7 +4,7 @@ import (
 	"encoding/binary"
 	"reflect"
 
-	"github.com/shamaton/msgpack/def"
+	"github.com/shamaton/msgpack/v2/def"
 )
 
 func (d *decoder) asUint(offset int, k reflect.Kind) (uint64, int, error) {

--- a/internal/encoding/bool.go
+++ b/internal/encoding/bool.go
@@ -1,6 +1,6 @@
 package encoding
 
-import "github.com/shamaton/msgpack/def"
+import "github.com/shamaton/msgpack/v2/def"
 
 //func (e *encoder) calcBool() int {
 //	return 0

--- a/internal/encoding/byte.go
+++ b/internal/encoding/byte.go
@@ -5,7 +5,7 @@ import (
 	"math"
 	"reflect"
 
-	"github.com/shamaton/msgpack/def"
+	"github.com/shamaton/msgpack/v2/def"
 )
 
 var typeByte = reflect.TypeOf(byte(0))

--- a/internal/encoding/complex.go
+++ b/internal/encoding/complex.go
@@ -3,7 +3,7 @@ package encoding
 import (
 	"math"
 
-	"github.com/shamaton/msgpack/def"
+	"github.com/shamaton/msgpack/v2/def"
 )
 
 func (e *encoder) calcComplex64() int {

--- a/internal/encoding/encoding.go
+++ b/internal/encoding/encoding.go
@@ -5,8 +5,8 @@ import (
 	"math"
 	"reflect"
 
-	"github.com/shamaton/msgpack/def"
-	"github.com/shamaton/msgpack/internal/common"
+	"github.com/shamaton/msgpack/v2/def"
+	"github.com/shamaton/msgpack/v2/internal/common"
 )
 
 type encoder struct {

--- a/internal/encoding/ext.go
+++ b/internal/encoding/ext.go
@@ -3,8 +3,8 @@ package encoding
 import (
 	"reflect"
 
-	"github.com/shamaton/msgpack/ext"
-	"github.com/shamaton/msgpack/time"
+	"github.com/shamaton/msgpack/v2/ext"
+	"github.com/shamaton/msgpack/v2/time"
 )
 
 var extCoderMap = map[reflect.Type]ext.Encoder{time.Encoder.Type(): time.Encoder}

--- a/internal/encoding/float.go
+++ b/internal/encoding/float.go
@@ -3,7 +3,7 @@ package encoding
 import (
 	"math"
 
-	"github.com/shamaton/msgpack/def"
+	"github.com/shamaton/msgpack/v2/def"
 )
 
 func (e *encoder) calcFloat32(v float64) int {

--- a/internal/encoding/int.go
+++ b/internal/encoding/int.go
@@ -3,7 +3,7 @@ package encoding
 import (
 	"math"
 
-	"github.com/shamaton/msgpack/def"
+	"github.com/shamaton/msgpack/v2/def"
 )
 
 func (e *encoder) isNegativeFixInt64(v int64) bool {

--- a/internal/encoding/map.go
+++ b/internal/encoding/map.go
@@ -4,7 +4,7 @@ import (
 	"math"
 	"reflect"
 
-	"github.com/shamaton/msgpack/def"
+	"github.com/shamaton/msgpack/v2/def"
 )
 
 func (e *encoder) calcFixedMap(rv reflect.Value) (int, bool) {

--- a/internal/encoding/nil.go
+++ b/internal/encoding/nil.go
@@ -1,6 +1,6 @@
 package encoding
 
-import "github.com/shamaton/msgpack/def"
+import "github.com/shamaton/msgpack/v2/def"
 
 func (e *encoder) writeNil(offset int) int {
 	offset = e.setByte1Int(def.Nil, offset)

--- a/internal/encoding/slice.go
+++ b/internal/encoding/slice.go
@@ -4,7 +4,7 @@ import (
 	"math"
 	"reflect"
 
-	"github.com/shamaton/msgpack/def"
+	"github.com/shamaton/msgpack/v2/def"
 )
 
 func (e *encoder) calcFixedSlice(rv reflect.Value) (int, bool) {

--- a/internal/encoding/string.go
+++ b/internal/encoding/string.go
@@ -4,7 +4,7 @@ import (
 	"math"
 	"unsafe"
 
-	"github.com/shamaton/msgpack/def"
+	"github.com/shamaton/msgpack/v2/def"
 )
 
 func (e *encoder) calcString(v string) int {

--- a/internal/encoding/struct.go
+++ b/internal/encoding/struct.go
@@ -6,8 +6,8 @@ import (
 	"reflect"
 	"sync"
 
-	"github.com/shamaton/msgpack/def"
-	"github.com/shamaton/msgpack/internal/common"
+	"github.com/shamaton/msgpack/v2/def"
+	"github.com/shamaton/msgpack/v2/internal/common"
 )
 
 type structCache struct {

--- a/internal/encoding/uint.go
+++ b/internal/encoding/uint.go
@@ -3,7 +3,7 @@ package encoding
 import (
 	"math"
 
-	"github.com/shamaton/msgpack/def"
+	"github.com/shamaton/msgpack/v2/def"
 )
 
 func (e *encoder) calcUint(v uint64) int {

--- a/msgpack.go
+++ b/msgpack.go
@@ -24,16 +24,6 @@ func Unmarshal(data []byte, v interface{}) error {
 	return decoding.Decode(data, v, StructAsArray)
 }
 
-// Deprecated: Use Marshal, this method will be deleted.
-func Encode(v interface{}) ([]byte, error) {
-	return encoding.Encode(v, StructAsArray)
-}
-
-// Deprecated: Use Unmarshal, this method will be deleted.
-func Decode(data []byte, v interface{}) error {
-	return decoding.Decode(data, v, StructAsArray)
-}
-
 // AddExtCoder adds encoders for extension types.
 func AddExtCoder(e ext.Encoder, d ext.Decoder) error {
 	if e.Code() != d.Code() {

--- a/msgpack.go
+++ b/msgpack.go
@@ -3,11 +3,10 @@ package msgpack
 import (
 	"fmt"
 
-	"github.com/shamaton/msgpack/def"
-
-	"github.com/shamaton/msgpack/ext"
-	"github.com/shamaton/msgpack/internal/decoding"
-	"github.com/shamaton/msgpack/internal/encoding"
+	"github.com/shamaton/msgpack/v2/def"
+	"github.com/shamaton/msgpack/v2/ext"
+	"github.com/shamaton/msgpack/v2/internal/decoding"
+	"github.com/shamaton/msgpack/v2/internal/encoding"
 )
 
 // StructAsArray is encoding option.

--- a/msgpack_test.go
+++ b/msgpack_test.go
@@ -12,9 +12,9 @@ import (
 	"testing"
 	"time"
 
-	"github.com/shamaton/msgpack"
-	"github.com/shamaton/msgpack/def"
-	"github.com/shamaton/msgpack/ext"
+	"github.com/shamaton/msgpack/v2"
+	"github.com/shamaton/msgpack/v2/def"
+	"github.com/shamaton/msgpack/v2/ext"
 )
 
 var now time.Time

--- a/msgpack_test.go
+++ b/msgpack_test.go
@@ -1357,21 +1357,19 @@ func testEmbedded(t *testing.T) {
 
 func testStructTag(t *testing.T) {
 	type vSt struct {
-		One int     `msgpack:"Three"`
-		Two string  `msgpack:"four"`
-		Ten float32 `msgpack:"ignore"`
-		Hfn bool    `msgpack:"-"`
+		One int    `msgpack:"Three"`
+		Two string `msgpack:"four"`
+		Hfn bool   `msgpack:"-"`
 	}
 	type rSt struct {
 		Three int
 		Four  string `msgpack:"four"`
-		Ten   float32
 		Hfn   bool
 	}
 
 	msgpack.StructAsArray = false
 
-	v := vSt{One: 1, Two: "2", Ten: 1.234, Hfn: true}
+	v := vSt{One: 1, Two: "2", Hfn: true}
 	r := rSt{}
 
 	d, err := msgpack.MarshalAsMap(v)
@@ -1385,7 +1383,7 @@ func testStructTag(t *testing.T) {
 	if err != nil {
 		t.Error(err)
 	}
-	if v.One != r.Three || v.Two != r.Four || r.Ten != 0 || r.Hfn != false {
+	if v.One != r.Three || v.Two != r.Four || r.Hfn != false {
 		t.Error("error:", v, r)
 	}
 }

--- a/time/decode.go
+++ b/time/decode.go
@@ -6,8 +6,8 @@ import (
 	"reflect"
 	"time"
 
-	"github.com/shamaton/msgpack/def"
-	"github.com/shamaton/msgpack/ext"
+	"github.com/shamaton/msgpack/v2/def"
+	"github.com/shamaton/msgpack/v2/ext"
 )
 
 var zero = time.Unix(0, 0)

--- a/time/encode.go
+++ b/time/encode.go
@@ -4,8 +4,8 @@ import (
 	"reflect"
 	"time"
 
-	"github.com/shamaton/msgpack/def"
-	"github.com/shamaton/msgpack/ext"
+	"github.com/shamaton/msgpack/v2/def"
+	"github.com/shamaton/msgpack/v2/ext"
 )
 
 var Encoder = new(timeEncoder)


### PR DESCRIPTION
* Add go modules, path is `github.com/shamaton/msgpack/v2`
* `Encode/Decode` methods can no longer be used
* Tag `msgpack:"ignore"` can no longer be used