### PR TITLE
Add RequireSafeStrings to prevent unsafe string unmarshalling; see #25

### DIFF
--- a/decode.go
+++ b/decode.go
@@ -5,11 +5,11 @@ import "github.com/shamaton/msgpack/v2/internal/decoding"
 // UnmarshalAsMap decodes data that is encoded as map format.
 // This is the same thing that StructAsArray sets false.
 func UnmarshalAsMap(data []byte, v interface{}) error {
-	return decoding.Decode(data, v, false)
+	return decoding.Decode(data, v, false, RequireSafeStrings)
 }
 
 // UnmarshalAsArray decodes data that is encoded as array format.
 // This is the same thing that StructAsArray sets true.
 func UnmarshalAsArray(data []byte, v interface{}) error {
-	return decoding.Decode(data, v, true)
+	return decoding.Decode(data, v, true, RequireSafeStrings)
 }

--- a/internal/decoding/decoding.go
+++ b/internal/decoding/decoding.go
@@ -8,15 +8,16 @@ import (
 )
 
 type decoder struct {
-	data    []byte
-	asArray bool
+	data         []byte
+	asArray      bool
+	stringSafety bool
 	common.Common
 }
 
 // Decode analyzes the MessagePack-encoded data and stores
 // the result into the pointer of v.
-func Decode(data []byte, v interface{}, asArray bool) error {
-	d := decoder{data: data, asArray: asArray}
+func Decode(data []byte, v interface{}, asArray, stringSafety bool) error {
+	d := decoder{data: data, asArray: asArray, stringSafety: stringSafety}
 
 	rv := reflect.ValueOf(v)
 	if rv.Kind() != reflect.Ptr {

--- a/internal/decoding/string.go
+++ b/internal/decoding/string.go
@@ -47,6 +47,9 @@ func (d *decoder) asString(offset int, k reflect.Kind) (string, int, error) {
 		return emptyString, 0, err
 	}
 	bs, offset := d.asStringByte(offset, l, k)
+	if d.stringSafety {
+		return string(bs), offset, nil
+	}
 	return *(*string)(unsafe.Pointer(&bs)), offset, nil
 }
 

--- a/msgpack.go
+++ b/msgpack.go
@@ -13,6 +13,10 @@ import (
 // If this option sets true, default encoding sets to array-format.
 var StructAsArray = false
 
+// RequireSafeStrings disables the use of unsafe to decode strings.  This is much slower, but makes
+// unmarshaled strings immutable.
+var RequireSafeStrings = false
+
 // Marshal returns the MessagePack-encoded byte array of v.
 func Marshal(v interface{}) ([]byte, error) {
 	return encoding.Encode(v, StructAsArray)
@@ -21,7 +25,7 @@ func Marshal(v interface{}) ([]byte, error) {
 // Unmarshal analyzes the MessagePack-encoded data and stores
 // the result into the pointer of v.
 func Unmarshal(data []byte, v interface{}) error {
-	return decoding.Decode(data, v, StructAsArray)
+	return decoding.Decode(data, v, StructAsArray, RequireSafeStrings)
 }
 
 // AddExtCoder adds encoders for extension types.


### PR DESCRIPTION
This PR introduces a global flag that disables the use of unsafe pointers to unmarshal strings.  I have some concerns about this PR, and therefore, it is just a draft:

* It adds a new option for unmarshalling, in addition to the flag to use arrays for structs.  If I were to imitate how this package handles the previous flag, I would double the number of unmarshalling methods.  I feel like this will get out of hand, since we would be going from two to four, and the next feature would take us from four to eight.  Perhaps it is better to add a Decoder type similar to `encoding/json` that can carry all these flags for users who need to meddle with them.
* It still leaves unsafe as a dependency.  I can see projects where unsafe is not permissible that may still want to use this package.  Perhaps it would have been better to make this something controlled by build tags.  (Google App Engine, for example, [does not allow unsafe](https://blog.golang.org/appengine).  Not sure if this is still true, since that post is from 2011)

Feel free to do what you want with this -- I'm happy to push it in either direction or just leave it alone.  I fixed the issue in my own project by swapping the strings in my package to byte slices to make it explicit that the fields are not immutable.  :)