### PR TITLE
Reimplement in terms of streaming instead of fixed slices

### DIFF
--- a/decode.go
+++ b/decode.go
@@ -5,11 +5,11 @@ import "github.com/shamaton/msgpack/v2/internal/decoding"
 // UnmarshalAsMap decodes data that is encoded as map format.
 // This is the same thing that StructAsArray sets false.
 func UnmarshalAsMap(data []byte, v interface{}) error {
-	return decoding.Decode(data, v, false)
+	return decoding.DecodeBytes(data, v, false)
 }
 
 // UnmarshalAsArray decodes data that is encoded as array format.
 // This is the same thing that StructAsArray sets true.
 func UnmarshalAsArray(data []byte, v interface{}) error {
-	return decoding.Decode(data, v, true)
+	return decoding.DecodeBytes(data, v, true)
 }

--- a/encode.go
+++ b/encode.go
@@ -7,11 +7,11 @@ import (
 // MarshalAsMap encodes data as map format.
 // This is the same thing that StructAsArray sets false.
 func MarshalAsMap(v interface{}) ([]byte, error) {
-	return encoding.Encode(v, false)
+	return encoding.EncodeBytes(v, false)
 }
 
 // MarshalAsArray encodes data as array format.
 // This is the same thing that StructAsArray sets true.
 func MarshalAsArray(v interface{}) ([]byte, error) {
-	return encoding.Encode(v, true)
+	return encoding.EncodeBytes(v, true)
 }

--- a/ext/decode.go
+++ b/ext/decode.go
@@ -2,39 +2,9 @@ package ext
 
 import (
 	"reflect"
-
-	"github.com/shamaton/msgpack/v2/def"
 )
 
 type Decoder interface {
 	Code() int8
-	IsType(offset int, d *[]byte) bool
-	AsValue(offset int, k reflect.Kind, d *[]byte) (interface{}, int, error)
-}
-
-type DecoderCommon struct {
-}
-
-func (cd *DecoderCommon) ReadSize1(index int, d *[]byte) (byte, int) {
-	rb := def.Byte1
-	return (*d)[index], index + rb
-}
-
-func (cd *DecoderCommon) ReadSize2(index int, d *[]byte) ([]byte, int) {
-	rb := def.Byte2
-	return (*d)[index : index+rb], index + rb
-}
-
-func (cd *DecoderCommon) ReadSize4(index int, d *[]byte) ([]byte, int) {
-	rb := def.Byte4
-	return (*d)[index : index+rb], index + rb
-}
-
-func (cd *DecoderCommon) ReadSize8(index int, d *[]byte) ([]byte, int) {
-	rb := def.Byte8
-	return (*d)[index : index+rb], index + rb
-}
-
-func (cd *DecoderCommon) ReadSizeN(index, n int, d *[]byte) ([]byte, int) {
-	return (*d)[index : index+n], index + n
+	AsValue(data []byte, k reflect.Kind) (interface{}, error)
 }

--- a/ext/encode.go
+++ b/ext/encode.go
@@ -1,6 +1,7 @@
 package ext
 
 import (
+	"io"
 	"reflect"
 )
 
@@ -8,104 +9,120 @@ type Encoder interface {
 	Code() int8
 	Type() reflect.Type
 	CalcByteSize(value reflect.Value) (int, error)
-	WriteToBytes(value reflect.Value, offset int, bytes *[]byte) int
+	WriteToBytes(value reflect.Value, writer io.Writer) error
 }
 
 type EncoderCommon struct {
 }
 
-func (c *EncoderCommon) SetByte1Int64(value int64, offset int, d *[]byte) int {
-	(*d)[offset] = byte(value)
-	return offset + 1
+func (c *EncoderCommon) SetByte1Int64(value int64, writer io.Writer) error {
+	_, err := writer.Write([]byte{byte(value)})
+	return err
 }
 
-func (c *EncoderCommon) SetByte2Int64(value int64, offset int, d *[]byte) int {
-	(*d)[offset+0] = byte(value >> 8)
-	(*d)[offset+1] = byte(value)
-	return offset + 2
+func (c *EncoderCommon) SetByte2Int64(value int64, writer io.Writer) error {
+	_, err := writer.Write([]byte{
+		byte(value >> 8),
+		byte(value),
+	})
+	return err
 }
 
-func (c *EncoderCommon) SetByte4Int64(value int64, offset int, d *[]byte) int {
-	(*d)[offset+0] = byte(value >> 24)
-	(*d)[offset+1] = byte(value >> 16)
-	(*d)[offset+2] = byte(value >> 8)
-	(*d)[offset+3] = byte(value)
-	return offset + 4
+func (c *EncoderCommon) SetByte4Int64(value int64, writer io.Writer) error {
+	_, err := writer.Write([]byte{
+		byte(value >> 24),
+		byte(value >> 16),
+		byte(value >> 8),
+		byte(value),
+	})
+	return err
 }
 
-func (c *EncoderCommon) SetByte8Int64(value int64, offset int, d *[]byte) int {
-	(*d)[offset] = byte(value >> 56)
-	(*d)[offset+1] = byte(value >> 48)
-	(*d)[offset+2] = byte(value >> 40)
-	(*d)[offset+3] = byte(value >> 32)
-	(*d)[offset+4] = byte(value >> 24)
-	(*d)[offset+5] = byte(value >> 16)
-	(*d)[offset+6] = byte(value >> 8)
-	(*d)[offset+7] = byte(value)
-	return offset + 8
+func (c *EncoderCommon) SetByte8Int64(value int64, writer io.Writer) error {
+	_, err := writer.Write([]byte{
+		byte(value >> 56),
+		byte(value >> 48),
+		byte(value >> 40),
+		byte(value >> 32),
+		byte(value >> 24),
+		byte(value >> 16),
+		byte(value >> 8),
+		byte(value),
+	})
+	return err
 }
 
-func (c *EncoderCommon) SetByte1Uint64(value uint64, offset int, d *[]byte) int {
-	(*d)[offset] = byte(value)
-	return offset + 1
+func (c *EncoderCommon) SetByte1Uint64(value uint64, writer io.Writer) error {
+	_, err := writer.Write([]byte{byte(value)})
+	return err
 }
 
-func (c *EncoderCommon) SetByte2Uint64(value uint64, offset int, d *[]byte) int {
-	(*d)[offset] = byte(value >> 8)
-	(*d)[offset+1] = byte(value)
-	return offset + 2
+func (c *EncoderCommon) SetByte2Uint64(value uint64, writer io.Writer) error {
+	_, err := writer.Write([]byte{
+		byte(value >> 8),
+		byte(value),
+	})
+	return err
 }
 
-func (c *EncoderCommon) SetByte4Uint64(value uint64, offset int, d *[]byte) int {
-	(*d)[offset] = byte(value >> 24)
-	(*d)[offset+1] = byte(value >> 16)
-	(*d)[offset+2] = byte(value >> 8)
-	(*d)[offset+3] = byte(value)
-	return offset + 4
+func (c *EncoderCommon) SetByte4Uint64(value uint64, writer io.Writer) error {
+	_, err := writer.Write([]byte{
+		byte(value >> 24),
+		byte(value >> 16),
+		byte(value >> 8),
+		byte(value),
+	})
+	return err
 }
 
-func (c *EncoderCommon) SetByte8Uint64(value uint64, offset int, d *[]byte) int {
-	(*d)[offset] = byte(value >> 56)
-	(*d)[offset+1] = byte(value >> 48)
-	(*d)[offset+2] = byte(value >> 40)
-	(*d)[offset+3] = byte(value >> 32)
-	(*d)[offset+4] = byte(value >> 24)
-	(*d)[offset+5] = byte(value >> 16)
-	(*d)[offset+6] = byte(value >> 8)
-	(*d)[offset+7] = byte(value)
-	return offset + 8
+func (c *EncoderCommon) SetByte8Uint64(value uint64, writer io.Writer) error {
+	_, err := writer.Write([]byte{
+		byte(value >> 56),
+		byte(value >> 48),
+		byte(value >> 40),
+		byte(value >> 32),
+		byte(value >> 24),
+		byte(value >> 16),
+		byte(value >> 8),
+		byte(value),
+	})
+	return err
 }
 
-func (c *EncoderCommon) SetByte1Int(code, offset int, d *[]byte) int {
-	(*d)[offset] = byte(code)
-	return offset + 1
+func (c *EncoderCommon) SetByte1Int(code int, writer io.Writer) error {
+	_, err := writer.Write([]byte{byte(code)})
+	return err
 }
 
-func (c *EncoderCommon) SetByte2Int(value int, offset int, d *[]byte) int {
-	(*d)[offset] = byte(value >> 8)
-	(*d)[offset+1] = byte(value)
-	return offset + 2
+func (c *EncoderCommon) SetByte2Int(value int, writer io.Writer) error {
+	_, err := writer.Write([]byte{
+		byte(value >> 8),
+		byte(value),
+	})
+	return err
 }
 
-func (c *EncoderCommon) SetByte4Int(value int, offset int, d *[]byte) int {
-	(*d)[offset] = byte(value >> 24)
-	(*d)[offset+1] = byte(value >> 16)
-	(*d)[offset+2] = byte(value >> 8)
-	(*d)[offset+3] = byte(value)
-	return offset + 4
+func (c *EncoderCommon) SetByte4Int(value int, writer io.Writer) error {
+	_, err := writer.Write([]byte{
+		byte(value >> 24),
+		byte(value >> 16),
+		byte(value >> 8),
+		byte(value),
+	})
+	return err
 }
 
-func (c *EncoderCommon) SetByte4Uint32(value uint32, offset int, d *[]byte) int {
-	(*d)[offset] = byte(value >> 24)
-	(*d)[offset+1] = byte(value >> 16)
-	(*d)[offset+2] = byte(value >> 8)
-	(*d)[offset+3] = byte(value)
-	return offset + 4
+func (c *EncoderCommon) SetByte4Uint32(value uint32, writer io.Writer) error {
+	_, err := writer.Write([]byte{
+		byte(value >> 24),
+		byte(value >> 16),
+		byte(value >> 8),
+		byte(value),
+	})
+	return err
 }
 
-func (c *EncoderCommon) SetBytes(bs []byte, offset int, d *[]byte) int {
-	for i := range bs {
-		(*d)[offset+i] = bs[i]
-	}
-	return offset + len(bs)
+func (c *EncoderCommon) SetBytes(bs []byte, writer io.Writer) error {
+	_, err := writer.Write(bs)
+	return err
 }

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,5 @@
 module github.com/shamaton/msgpack/v2
 
 go 1.15
+
+require github.com/josharian/intern v1.0.0

--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,3 @@
 module github.com/shamaton/msgpack/v2
 
 go 1.15
-
-require github.com/josharian/intern v1.0.0

--- a/internal/decoding/bin.go
+++ b/internal/decoding/bin.go
@@ -55,5 +55,5 @@ func (d *decoder) asBinC(reader *bufio.Reader, code byte, k reflect.Kind) ([]byt
 
 func (d *decoder) asBinStringC(reader *bufio.Reader, code byte, k reflect.Kind) (string, error) {
 	bs, err := d.asBinC(reader, code, k)
-	return string(bs), err
+	return d.maybeInternString(bs), err
 }

--- a/internal/decoding/bin.go
+++ b/internal/decoding/bin.go
@@ -36,14 +36,14 @@ func (d *decoder) asBin(reader *bufio.Reader, k reflect.Kind) ([]byte, error) {
 			return nil, err
 		}
 
-		return d.readSizeN(reader, int(binary.BigEndian.Uint16(bs)))
+		return d.readSizeN(reader, int(binary.BigEndian.Uint16(bs[:])))
 	case def.Bin32:
 		bs, err := d.readSize4(reader)
 		if err != nil {
 			return nil, err
 		}
 
-		return d.readSizeN(reader, int(binary.BigEndian.Uint32(bs)))
+		return d.readSizeN(reader, int(binary.BigEndian.Uint32(bs[:])))
 	}
 
 	return emptyBytes, d.errorTemplate(code, k)

--- a/internal/decoding/bin.go
+++ b/internal/decoding/bin.go
@@ -22,6 +22,10 @@ func (d *decoder) asBin(reader *bufio.Reader, k reflect.Kind) ([]byte, error) {
 		return nil, err
 	}
 
+	return d.asBinC(reader, code, k)
+}
+
+func (d *decoder) asBinC(reader *bufio.Reader, code byte, k reflect.Kind) ([]byte, error) {
 	switch code {
 	case def.Bin8:
 		l, err := d.readSize1(reader)
@@ -49,7 +53,7 @@ func (d *decoder) asBin(reader *bufio.Reader, k reflect.Kind) ([]byte, error) {
 	return emptyBytes, d.errorTemplate(code, k)
 }
 
-func (d *decoder) asBinString(reader *bufio.Reader, k reflect.Kind) (string, error) {
-	bs, err := d.asBin(reader, k)
+func (d *decoder) asBinStringC(reader *bufio.Reader, code byte, k reflect.Kind) (string, error) {
+	bs, err := d.asBinC(reader, code, k)
 	return string(bs), err
 }

--- a/internal/decoding/bin.go
+++ b/internal/decoding/bin.go
@@ -22,7 +22,6 @@ func (d *decoder) asBin(reader *bufio.Reader, k reflect.Kind) ([]byte, error) {
 		return nil, err
 	}
 
-
 	switch code {
 	case def.Bin8:
 		l, err := d.readSize1(reader)

--- a/internal/decoding/bool.go
+++ b/internal/decoding/bool.go
@@ -1,20 +1,24 @@
 package decoding
 
 import (
+	"bufio"
 	"reflect"
 
 	"github.com/shamaton/msgpack/v2/def"
 )
 
-func (d *decoder) asBool(offset int, k reflect.Kind) (bool, int, error) {
-	code := d.data[offset]
-	offset++
+func (d *decoder) asBool(reader *bufio.Reader, k reflect.Kind) (bool, error) {
+	code, err := reader.ReadByte()
+	if err != nil {
+		return false, err
+	}
 
 	switch code {
 	case def.True:
-		return true, offset, nil
+		return true, nil
 	case def.False:
-		return false, offset, nil
+		return false, nil
 	}
-	return false, 0, d.errorTemplate(code, k)
+
+	return false, d.errorTemplate(code, k)
 }

--- a/internal/decoding/complex.go
+++ b/internal/decoding/complex.go
@@ -33,8 +33,8 @@ func (d *decoder) asComplex64(reader *bufio.Reader, k reflect.Kind) (complex64, 
 		if err != nil {
 			return complex(0, 0), err
 		}
-		r := math.Float32frombits(binary.BigEndian.Uint32(rb))
-		i := math.Float32frombits(binary.BigEndian.Uint32(ib))
+		r := math.Float32frombits(binary.BigEndian.Uint32(rb[:]))
+		i := math.Float32frombits(binary.BigEndian.Uint32(ib[:]))
 		return complex(r, i), nil
 
 	case def.Fixext16:
@@ -53,8 +53,8 @@ func (d *decoder) asComplex64(reader *bufio.Reader, k reflect.Kind) (complex64, 
 		if err != nil {
 			return complex(0, 0), err
 		}
-		r := math.Float64frombits(binary.BigEndian.Uint64(rb))
-		i := math.Float64frombits(binary.BigEndian.Uint64(ib))
+		r := math.Float64frombits(binary.BigEndian.Uint64(rb[:]))
+		i := math.Float64frombits(binary.BigEndian.Uint64(ib[:]))
 		return complex64(complex(r, i)), nil
 
 	}
@@ -85,8 +85,8 @@ func (d *decoder) asComplex128(reader *bufio.Reader, k reflect.Kind) (complex128
 		if err != nil {
 			return complex(0, 0), err
 		}
-		r := math.Float32frombits(binary.BigEndian.Uint32(rb))
-		i := math.Float32frombits(binary.BigEndian.Uint32(ib))
+		r := math.Float32frombits(binary.BigEndian.Uint32(rb[:]))
+		i := math.Float32frombits(binary.BigEndian.Uint32(ib[:]))
 		return complex128(complex(r, i)), nil
 
 	case def.Fixext16:
@@ -105,8 +105,8 @@ func (d *decoder) asComplex128(reader *bufio.Reader, k reflect.Kind) (complex128
 		if err != nil {
 			return complex(0, 0), err
 		}
-		r := math.Float64frombits(binary.BigEndian.Uint64(rb))
-		i := math.Float64frombits(binary.BigEndian.Uint64(ib))
+		r := math.Float64frombits(binary.BigEndian.Uint64(rb[:]))
+		i := math.Float64frombits(binary.BigEndian.Uint64(ib[:]))
 		return complex(r, i), nil
 
 	}

--- a/internal/decoding/complex.go
+++ b/internal/decoding/complex.go
@@ -1,6 +1,7 @@
 package decoding
 
 import (
+	"bufio"
 	"encoding/binary"
 	"fmt"
 	"math"
@@ -9,64 +10,106 @@ import (
 	"github.com/shamaton/msgpack/v2/def"
 )
 
-func (d *decoder) asComplex64(offset int, k reflect.Kind) (complex64, int, error) {
-	code, offset := d.readSize1(offset)
+func (d *decoder) asComplex64(reader *bufio.Reader, k reflect.Kind) (complex64, error) {
+	code, err := reader.ReadByte()
+	if err != nil {
+		return complex(0, 0), err
+	}
 
 	switch code {
 	case def.Fixext8:
-		t, offset := d.readSize1(offset)
-		if int8(t) != def.ComplexTypeCode() {
-			return complex(0, 0), 0, fmt.Errorf("fixext8. complex type is diffrent %d, %d", t, def.ComplexTypeCode())
+		t, err := d.readSize1(reader)
+		if err != nil {
+			return complex(0, 0), err
 		}
-		rb, offset := d.readSize4(offset)
-		ib, offset := d.readSize4(offset)
+		if int8(t) != def.ComplexTypeCode() {
+			return complex(0, 0), fmt.Errorf("fixext8. complex type is diffrent %d, %d", t, def.ComplexTypeCode())
+		}
+		rb, err := d.readSize4(reader)
+		if err != nil {
+			return complex(0, 0), err
+		}
+		ib, err := d.readSize4(reader)
+		if err != nil {
+			return complex(0, 0), err
+		}
 		r := math.Float32frombits(binary.BigEndian.Uint32(rb))
 		i := math.Float32frombits(binary.BigEndian.Uint32(ib))
-		return complex(r, i), offset, nil
+		return complex(r, i), nil
 
 	case def.Fixext16:
-		t, offset := d.readSize1(offset)
-		if int8(t) != def.ComplexTypeCode() {
-			return complex(0, 0), 0, fmt.Errorf("fixext16. complex type is diffrent %d, %d", t, def.ComplexTypeCode())
+		t, err := d.readSize1(reader)
+		if err != nil {
+			return complex(0, 0), err
 		}
-		rb, offset := d.readSize8(offset)
-		ib, offset := d.readSize8(offset)
+		if int8(t) != def.ComplexTypeCode() {
+			return complex(0, 0), fmt.Errorf("fixext16. complex type is diffrent %d, %d", t, def.ComplexTypeCode())
+		}
+		rb, err := d.readSize8(reader)
+		if err != nil {
+			return complex(0, 0), err
+		}
+		ib, err := d.readSize8(reader)
+		if err != nil {
+			return complex(0, 0), err
+		}
 		r := math.Float64frombits(binary.BigEndian.Uint64(rb))
 		i := math.Float64frombits(binary.BigEndian.Uint64(ib))
-		return complex64(complex(r, i)), offset, nil
+		return complex64(complex(r, i)), nil
 
 	}
 
-	return complex(0, 0), 0, fmt.Errorf("should not reach this line!! code %x decoding %v", code, k)
+	return complex(0, 0), fmt.Errorf("should not reach this line!! code %x decoding %v", code, k)
 }
 
-func (d *decoder) asComplex128(offset int, k reflect.Kind) (complex128, int, error) {
-	code, offset := d.readSize1(offset)
+func (d *decoder) asComplex128(reader *bufio.Reader, k reflect.Kind) (complex128, error) {
+	code, err := reader.ReadByte()
+	if err != nil {
+		return complex(0, 0), err
+	}
 
 	switch code {
 	case def.Fixext8:
-		t, offset := d.readSize1(offset)
-		if int8(t) != def.ComplexTypeCode() {
-			return complex(0, 0), 0, fmt.Errorf("fixext8. complex type is diffrent %d, %d", t, def.ComplexTypeCode())
+		t, err := d.readSize1(reader)
+		if err != nil {
+			return complex(0, 0), err
 		}
-		rb, offset := d.readSize4(offset)
-		ib, offset := d.readSize4(offset)
+		if int8(t) != def.ComplexTypeCode() {
+			return complex(0, 0), fmt.Errorf("fixext8. complex type is diffrent %d, %d", t, def.ComplexTypeCode())
+		}
+		rb, err := d.readSize4(reader)
+		if err != nil {
+			return complex(0, 0), err
+		}
+		ib, err := d.readSize4(reader)
+		if err != nil {
+			return complex(0, 0), err
+		}
 		r := math.Float32frombits(binary.BigEndian.Uint32(rb))
 		i := math.Float32frombits(binary.BigEndian.Uint32(ib))
-		return complex128(complex(r, i)), offset, nil
+		return complex128(complex(r, i)), nil
 
 	case def.Fixext16:
-		t, offset := d.readSize1(offset)
-		if int8(t) != def.ComplexTypeCode() {
-			return complex(0, 0), 0, fmt.Errorf("fixext16. complex type is diffrent %d, %d", t, def.ComplexTypeCode())
+		t, err := d.readSize1(reader)
+		if err != nil {
+			return complex(0, 0), err
 		}
-		rb, offset := d.readSize8(offset)
-		ib, offset := d.readSize8(offset)
+		if int8(t) != def.ComplexTypeCode() {
+			return complex(0, 0), fmt.Errorf("fixext16. complex type is diffrent %d, %d", t, def.ComplexTypeCode())
+		}
+		rb, err := d.readSize8(reader)
+		if err != nil {
+			return complex(0, 0), err
+		}
+		ib, err := d.readSize8(reader)
+		if err != nil {
+			return complex(0, 0), err
+		}
 		r := math.Float64frombits(binary.BigEndian.Uint64(rb))
 		i := math.Float64frombits(binary.BigEndian.Uint64(ib))
-		return complex(r, i), offset, nil
+		return complex(r, i), nil
 
 	}
 
-	return complex(0, 0), 0, fmt.Errorf("should not reach this line!! code %x decoding %v", code, k)
+	return complex(0, 0), fmt.Errorf("should not reach this line!! code %x decoding %v", code, k)
 }

--- a/internal/decoding/decoding.go
+++ b/internal/decoding/decoding.go
@@ -140,7 +140,7 @@ func (d *decoder) decode(rv reflect.Value, reader *bufio.Reader) error {
 			rv.SetString(v)
 			return nil
 		}
-		v, err := d.asStringByteC(reader, code, nil, k)
+		v, err := d.asStringByteC(reader, code, k)
 		if err != nil {
 			return err
 		}
@@ -176,7 +176,7 @@ func (d *decoder) decode(rv reflect.Value, reader *bufio.Reader) error {
 
 		// string to bytes
 		if d.isCodeString(code) {
-			bs, err := d.asStringByteC(reader, code, nil, k)
+			bs, err := d.asStringByteC(reader, code, k)
 			if err != nil {
 				return err
 			}
@@ -257,7 +257,7 @@ func (d *decoder) decode(rv reflect.Value, reader *bufio.Reader) error {
 		}
 		// string to bytes
 		if d.isCodeString(code) {
-			bs, err := d.asStringByteC(reader, code, nil, k)
+			bs, err := d.asStringByteC(reader, code, k)
 			if err != nil {
 				return err
 			}

--- a/internal/decoding/decoding.go
+++ b/internal/decoding/decoding.go
@@ -3,9 +3,11 @@ package decoding
 import (
 	"bufio"
 	"bytes"
+	"errors"
 	"fmt"
 	"io"
 	"reflect"
+	"strconv"
 
 	"github.com/shamaton/msgpack/v2/internal/common"
 )
@@ -245,7 +247,9 @@ func (d *decoder) decode(rv reflect.Value, reader *bufio.Reader) error {
 				return err
 			}
 			if len(bs) > rv.Len() {
-				return fmt.Errorf("%v len is %d, but msgpack has %d elements", rv.Type(), rv.Len(), len(bs))
+				return errors.New(rv.Type().String() + " len is " +
+					strconv.FormatInt(int64(rv.Len()), 10) + ", but msgpack has "+
+					strconv.FormatInt(int64(len(bs)), 10) +" elements")
 			}
 			for i, b := range bs {
 				rv.Index(i).SetUint(uint64(b))
@@ -259,7 +263,9 @@ func (d *decoder) decode(rv reflect.Value, reader *bufio.Reader) error {
 				return err
 			}
 			if l > rv.Len() {
-				return fmt.Errorf("%v len is %d, but msgpack has %d elements", rv.Type(), rv.Len(), l)
+				return errors.New(rv.Type().String() + " len is " +
+					strconv.FormatInt(int64(rv.Len()), 10) + ", but msgpack has "+
+					strconv.FormatInt(int64(l), 10) +" elements")
 			}
 			bs, err := d.asStringByteByLength(reader, l, k)
 			if err != nil {
@@ -278,7 +284,9 @@ func (d *decoder) decode(rv reflect.Value, reader *bufio.Reader) error {
 		}
 
 		if l > rv.Len() {
-			return fmt.Errorf("%v len is %d, but msgpack has %d elements", rv.Type(), rv.Len(), l)
+			return errors.New(rv.Type().String() + " len is " +
+				strconv.FormatInt(int64(rv.Len()), 10) + ", but msgpack has "+
+				strconv.FormatInt(int64(l), 10) +" elements")
 		}
 
 		// create array dynamically
@@ -389,5 +397,5 @@ func (d *decoder) decode(rv reflect.Value, reader *bufio.Reader) error {
 }
 
 func (d *decoder) errorTemplate(code byte, k reflect.Kind) error {
-	return fmt.Errorf("msgpack : invalid code %x decoding %v", code, k)
+	return errors.New("msgpack : invalid code " + strconv.FormatInt(int64(code), 16) + " decoding " + k.String())
 }

--- a/internal/decoding/ext.go
+++ b/internal/decoding/ext.go
@@ -117,7 +117,7 @@ func (d *decoder) readExt(reader *bufio.Reader) (byte, []byte, error) {
 	case def.Ext8:
 		v, err := d.readSize1(reader)
 		if err != nil {
-			return 0, nil ,err
+			return 0, nil, err
 		}
 		code, err = reader.ReadByte()
 		if err != nil {

--- a/internal/decoding/ext.go
+++ b/internal/decoding/ext.go
@@ -53,7 +53,7 @@ func updateExtCoders() {
 var errNotExt = errors.New("not an Ext value")
 
 func (d *decoder) readExt(reader *bufio.Reader) (byte, []byte, error) {
-	code, err := peekCode(reader)
+	code, err := reader.ReadByte()
 	if err != nil {
 		return 0, nil, err
 	}
@@ -69,12 +69,11 @@ func (d *decoder) readExt(reader *bufio.Reader) (byte, []byte, error) {
 	case def.Ext16:
 	case def.Ext32:
 	default:
+		err = reader.UnreadByte()
+		if err != nil {
+			return 0, nil, err
+		}
 		return 0, nil, errNotExt
-	}
-
-	err = skipOne(reader)
-	if err != nil {
-		return 0, nil, err
 	}
 
 	switch code {

--- a/internal/decoding/ext.go
+++ b/internal/decoding/ext.go
@@ -91,21 +91,21 @@ func (d *decoder) readExt(reader *bufio.Reader) (byte, []byte, error) {
 			return 0, nil, err
 		}
 		data, err := d.readSize2(reader)
-		return code, data, err
+		return code, data[:], err
 	case def.Fixext4:
 		code, err = reader.ReadByte()
 		if err != nil {
 			return 0, nil, err
 		}
 		data, err := d.readSize4(reader)
-		return code, data, err
+		return code, data[:], err
 	case def.Fixext8:
 		code, err = reader.ReadByte()
 		if err != nil {
 			return 0, nil, err
 		}
 		data, err := d.readSize8(reader)
-		return code, data, err
+		return code, data[:], err
 	case def.Fixext16:
 		code, err = reader.ReadByte()
 		if err != nil {
@@ -134,7 +134,7 @@ func (d *decoder) readExt(reader *bufio.Reader) (byte, []byte, error) {
 		if err != nil {
 			return 0, nil, err
 		}
-		v := binary.BigEndian.Uint16(bs)
+		v := binary.BigEndian.Uint16(bs[:])
 		data, err := d.readSizeN(reader, int(v))
 		return code, data, err
 	case def.Ext32:
@@ -146,7 +146,7 @@ func (d *decoder) readExt(reader *bufio.Reader) (byte, []byte, error) {
 		if err != nil {
 			return 0, nil, err
 		}
-		v := binary.BigEndian.Uint32(bs)
+		v := binary.BigEndian.Uint32(bs[:])
 		data, err := d.readSizeN(reader, int(v))
 		return code, data, err
 

--- a/internal/decoding/float.go
+++ b/internal/decoding/float.go
@@ -26,7 +26,7 @@ func (d *decoder) asFloat32(reader *bufio.Reader, k reflect.Kind) (float32, erro
 		if err != nil {
 			return 0, err
 		}
-		v := math.Float32frombits(binary.BigEndian.Uint32(bs))
+		v := math.Float32frombits(binary.BigEndian.Uint32(bs[:]))
 		return v, nil
 
 	case d.isPositiveFixNum(code), code == def.Uint8, code == def.Uint16, code == def.Uint32, code == def.Uint64:
@@ -72,7 +72,7 @@ func (d *decoder) asFloat64(reader *bufio.Reader, k reflect.Kind) (float64, erro
 		if err != nil {
 			return 0, err
 		}
-		v := math.Float64frombits(binary.BigEndian.Uint64(bs))
+		v := math.Float64frombits(binary.BigEndian.Uint64(bs[:]))
 		return v, nil
 
 	case code == def.Float32:
@@ -85,7 +85,7 @@ func (d *decoder) asFloat64(reader *bufio.Reader, k reflect.Kind) (float64, erro
 		if err != nil {
 			return 0, err
 		}
-		v := math.Float32frombits(binary.BigEndian.Uint32(bs))
+		v := math.Float32frombits(binary.BigEndian.Uint32(bs[:]))
 		return float64(v), nil
 
 	case d.isPositiveFixNum(code), code == def.Uint8, code == def.Uint16, code == def.Uint32, code == def.Uint64:

--- a/internal/decoding/float.go
+++ b/internal/decoding/float.go
@@ -10,18 +10,17 @@ import (
 )
 
 func (d *decoder) asFloat32(reader *bufio.Reader, k reflect.Kind) (float32, error) {
-	code, err := peekCode(reader)
+	code, err := d.readSize1(reader)
 	if err != nil {
 		return 0, err
 	}
 
+	return d.asFloat32C(reader, code, k)
+}
+
+func (d *decoder) asFloat32C(reader *bufio.Reader, code byte, k reflect.Kind) (float32, error) {
 	switch {
 	case code == def.Float32:
-		err = skipOne(reader)
-		if err != nil {
-			return 0, err
-		}
-
 		bs, err := d.readSize4(reader)
 		if err != nil {
 			return 0, err
@@ -30,6 +29,10 @@ func (d *decoder) asFloat32(reader *bufio.Reader, k reflect.Kind) (float32, erro
 		return v, nil
 
 	case d.isPositiveFixNum(code), code == def.Uint8, code == def.Uint16, code == def.Uint32, code == def.Uint64:
+		err := reader.UnreadByte()
+		if err != nil {
+			return 0, err
+		}
 		v, err := d.asUint(reader, k)
 		if err != nil {
 			break
@@ -37,6 +40,10 @@ func (d *decoder) asFloat32(reader *bufio.Reader, k reflect.Kind) (float32, erro
 		return float32(v), nil
 
 	case d.isNegativeFixNum(code), code == def.Int8, code == def.Int16, code == def.Int32, code == def.Int64:
+		err := reader.UnreadByte()
+		if err != nil {
+			return 0, err
+		}
 		v, err := d.asInt(reader, k)
 		if err != nil {
 			break
@@ -44,11 +51,6 @@ func (d *decoder) asFloat32(reader *bufio.Reader, k reflect.Kind) (float32, erro
 		return float32(v), nil
 
 	case code == def.Nil:
-		err = skipOne(reader)
-		if err != nil {
-			return 0, err
-		}
-
 		return 0, nil
 	}
 
@@ -56,18 +58,17 @@ func (d *decoder) asFloat32(reader *bufio.Reader, k reflect.Kind) (float32, erro
 }
 
 func (d *decoder) asFloat64(reader *bufio.Reader, k reflect.Kind) (float64, error) {
-	code, err := peekCode(reader)
+	code, err := d.readSize1(reader)
 	if err != nil {
 		return 0, err
 	}
 
+	return d.asFloat64C(reader, code, k)
+}
+
+func (d *decoder) asFloat64C(reader *bufio.Reader, code byte, k reflect.Kind) (float64, error) {
 	switch {
 	case code == def.Float64:
-		err = skipOne(reader)
-		if err != nil {
-			return 0, err
-		}
-
 		bs, err := d.readSize8(reader)
 		if err != nil {
 			return 0, err
@@ -76,11 +77,6 @@ func (d *decoder) asFloat64(reader *bufio.Reader, k reflect.Kind) (float64, erro
 		return v, nil
 
 	case code == def.Float32:
-		err = skipOne(reader)
-		if err != nil {
-			return 0, err
-		}
-
 		bs, err := d.readSize4(reader)
 		if err != nil {
 			return 0, err
@@ -89,6 +85,11 @@ func (d *decoder) asFloat64(reader *bufio.Reader, k reflect.Kind) (float64, erro
 		return float64(v), nil
 
 	case d.isPositiveFixNum(code), code == def.Uint8, code == def.Uint16, code == def.Uint32, code == def.Uint64:
+		err := reader.UnreadByte()
+		if err != nil {
+			return 0, err
+		}
+
 		v, err := d.asUint(reader, k)
 		if err != nil {
 			break
@@ -96,6 +97,11 @@ func (d *decoder) asFloat64(reader *bufio.Reader, k reflect.Kind) (float64, erro
 		return float64(v), nil
 
 	case d.isNegativeFixNum(code), code == def.Int8, code == def.Int16, code == def.Int32, code == def.Int64:
+		err := reader.UnreadByte()
+		if err != nil {
+			return 0, err
+		}
+
 		v, err := d.asInt(reader, k)
 		if err != nil {
 			break
@@ -103,11 +109,6 @@ func (d *decoder) asFloat64(reader *bufio.Reader, k reflect.Kind) (float64, erro
 		return float64(v), nil
 
 	case code == def.Nil:
-		err = skipOne(reader)
-		if err != nil {
-			return 0, err
-		}
-
 		return 0, nil
 	}
 

--- a/internal/decoding/float.go
+++ b/internal/decoding/float.go
@@ -1,6 +1,7 @@
 package decoding
 
 import (
+	"bufio"
 	"encoding/binary"
 	"math"
 	"reflect"
@@ -8,70 +9,107 @@ import (
 	"github.com/shamaton/msgpack/v2/def"
 )
 
-func (d *decoder) asFloat32(offset int, k reflect.Kind) (float32, int, error) {
-	code := d.data[offset]
+func (d *decoder) asFloat32(reader *bufio.Reader, k reflect.Kind) (float32, error) {
+	code, err := peekCode(reader)
+	if err != nil {
+		return 0, err
+	}
 
 	switch {
 	case code == def.Float32:
-		offset++
-		bs, offset := d.readSize4(offset)
+		err = skipOne(reader)
+		if err != nil {
+			return 0, err
+		}
+
+		bs, err := d.readSize4(reader)
+		if err != nil {
+			return 0, err
+		}
 		v := math.Float32frombits(binary.BigEndian.Uint32(bs))
-		return v, offset, nil
+		return v, nil
 
 	case d.isPositiveFixNum(code), code == def.Uint8, code == def.Uint16, code == def.Uint32, code == def.Uint64:
-		v, offset, err := d.asUint(offset, k)
+		v, err := d.asUint(reader, k)
 		if err != nil {
 			break
 		}
-		return float32(v), offset, nil
+		return float32(v), nil
 
 	case d.isNegativeFixNum(code), code == def.Int8, code == def.Int16, code == def.Int32, code == def.Int64:
-		v, offset, err := d.asInt(offset, k)
+		v, err := d.asInt(reader, k)
 		if err != nil {
 			break
 		}
-		return float32(v), offset, nil
+		return float32(v), nil
 
 	case code == def.Nil:
-		offset++
-		return 0, offset, nil
+		err = skipOne(reader)
+		if err != nil {
+			return 0, err
+		}
+
+		return 0, nil
 	}
-	return 0, 0, d.errorTemplate(code, k)
+
+	return 0, d.errorTemplate(code, k)
 }
 
-func (d *decoder) asFloat64(offset int, k reflect.Kind) (float64, int, error) {
-	code := d.data[offset]
+func (d *decoder) asFloat64(reader *bufio.Reader, k reflect.Kind) (float64, error) {
+	code, err := peekCode(reader)
+	if err != nil {
+		return 0, err
+	}
 
 	switch {
 	case code == def.Float64:
-		offset++
-		bs, offset := d.readSize8(offset)
+		err = skipOne(reader)
+		if err != nil {
+			return 0, err
+		}
+
+		bs, err := d.readSize8(reader)
+		if err != nil {
+			return 0, err
+		}
 		v := math.Float64frombits(binary.BigEndian.Uint64(bs))
-		return v, offset, nil
+		return v, nil
 
 	case code == def.Float32:
-		offset++
-		bs, offset := d.readSize4(offset)
+		err = skipOne(reader)
+		if err != nil {
+			return 0, err
+		}
+
+		bs, err := d.readSize4(reader)
+		if err != nil {
+			return 0, err
+		}
 		v := math.Float32frombits(binary.BigEndian.Uint32(bs))
-		return float64(v), offset, nil
+		return float64(v), nil
 
 	case d.isPositiveFixNum(code), code == def.Uint8, code == def.Uint16, code == def.Uint32, code == def.Uint64:
-		v, offset, err := d.asUint(offset, k)
+		v, err := d.asUint(reader, k)
 		if err != nil {
 			break
 		}
-		return float64(v), offset, nil
+		return float64(v), nil
 
 	case d.isNegativeFixNum(code), code == def.Int8, code == def.Int16, code == def.Int32, code == def.Int64:
-		v, offset, err := d.asInt(offset, k)
+		v, err := d.asInt(reader, k)
 		if err != nil {
 			break
 		}
-		return float64(v), offset, nil
+		return float64(v), nil
 
 	case code == def.Nil:
-		offset++
-		return 0, offset, nil
+		err = skipOne(reader)
+		if err != nil {
+			return 0, err
+		}
+
+		return 0, nil
 	}
-	return 0, 0, d.errorTemplate(code, k)
+
+	return 0, d.errorTemplate(code, k)
 }

--- a/internal/decoding/int.go
+++ b/internal/decoding/int.go
@@ -1,6 +1,7 @@
 package decoding
 
 import (
+	"bufio"
 	"encoding/binary"
 	"reflect"
 
@@ -15,81 +16,144 @@ func (d *decoder) isNegativeFixNum(v byte) bool {
 	return def.NegativeFixintMin <= int8(v) && int8(v) <= def.NegativeFixintMax
 }
 
-func (d *decoder) asInt(offset int, k reflect.Kind) (int64, int, error) {
-
-	code := d.data[offset]
+func (d *decoder) asInt(reader *bufio.Reader, k reflect.Kind) (int64, error) {
+	code, err := peekCode(reader)
+	if err != nil {
+		return 0, err
+	}
 
 	switch {
 	case d.isPositiveFixNum(code):
-		b, offset := d.readSize1(offset)
-		return int64(b), offset, nil
+		b, err := d.readSize1(reader)
+		if err != nil {
+			return 0, err
+		}
+		return int64(b), nil
 
 	case d.isNegativeFixNum(code):
-		b, offset := d.readSize1(offset)
-		return int64(int8(b)), offset, nil
+		b, err := d.readSize1(reader)
+		if err != nil {
+			return 0, err
+		}
+		return int64(int8(b)), nil
 
 	case code == def.Uint8:
-		offset++
-		b, offset := d.readSize1(offset)
-		return int64(uint8(b)), offset, nil
+		err = skipOne(reader)
+		if err != nil {
+			return 0, err
+		}
+
+		b, err := d.readSize1(reader)
+		if err != nil {
+			return 0, err
+		}
+		return int64(uint8(b)), nil
 
 	case code == def.Int8:
-		offset++
-		b, offset := d.readSize1(offset)
-		return int64(int8(b)), offset, nil
+		err = skipOne(reader)
+		if err != nil {
+			return 0, err
+		}
+
+		b, err := d.readSize1(reader)
+		if err != nil {
+			return 0, err
+		}
+		return int64(int8(b)), nil
 
 	case code == def.Uint16:
-		offset++
-		bs, offset := d.readSize2(offset)
+		err = skipOne(reader)
+		if err != nil {
+			return 0, err
+		}
+
+		bs, err := d.readSize2(reader)
+		if err != nil {
+			return 0, err
+		}
 		v := binary.BigEndian.Uint16(bs)
-		return int64(v), offset, nil
+		return int64(v), nil
 
 	case code == def.Int16:
-		offset++
-		bs, offset := d.readSize2(offset)
+		err = skipOne(reader)
+		if err != nil {
+			return 0, err
+		}
+
+		bs, err := d.readSize2(reader)
+		if err != nil {
+			return 0, err
+		}
 		v := int16(binary.BigEndian.Uint16(bs))
-		return int64(v), offset, nil
+		return int64(v), nil
 
 	case code == def.Uint32:
-		offset++
-		bs, offset := d.readSize4(offset)
+		err = skipOne(reader)
+		if err != nil {
+			return 0, err
+		}
+
+		bs, err := d.readSize4(reader)
+		if err != nil {
+			return 0, err
+		}
 		v := binary.BigEndian.Uint32(bs)
-		return int64(v), offset, nil
+		return int64(v), nil
 
 	case code == def.Int32:
-		offset++
-		bs, offset := d.readSize4(offset)
+		err = skipOne(reader)
+		if err != nil {
+			return 0, err
+		}
+
+		bs, err := d.readSize4(reader)
+		if err != nil {
+			return 0, err
+		}
 		v := int32(binary.BigEndian.Uint32(bs))
-		return int64(v), offset, nil
+		return int64(v), nil
 
 	case code == def.Uint64:
-		offset++
-		bs, offset := d.readSize8(offset)
-		return int64(binary.BigEndian.Uint64(bs)), offset, nil
+		err = skipOne(reader)
+		if err != nil {
+			return 0, err
+		}
+
+		bs, err := d.readSize8(reader)
+		if err != nil {
+			return 0, err
+		}
+		return int64(binary.BigEndian.Uint64(bs)), nil
 
 	case code == def.Int64:
-		offset++
-		bs, offset := d.readSize8(offset)
-		return int64(binary.BigEndian.Uint64(bs)), offset, nil
+		err = skipOne(reader)
+		if err != nil {
+			return 0, err
+		}
+
+		bs, err := d.readSize8(reader)
+		if err != nil {
+			return 0, err
+		}
+		return int64(binary.BigEndian.Uint64(bs)), nil
 
 	case code == def.Float32:
-		v, offset, err := d.asFloat32(offset, k)
+		v, err := d.asFloat32(reader, k)
 		if err != nil {
-			return 0, 0, err
+			return 0, err
 		}
-		return int64(v), offset, nil
+		return int64(v), nil
 
 	case code == def.Float64:
-		v, offset, err := d.asFloat64(offset, k)
+		v, err := d.asFloat64(reader, k)
 		if err != nil {
-			return 0, 0, err
+			return 0, err
 		}
-		return int64(v), offset, nil
+		return int64(v), nil
 
 	case code == def.Nil:
-		offset++
-		return 0, offset, nil
+		return 0, nil
 	}
 
-	return 0, 0, d.errorTemplate(code, k)
+	return 0, d.errorTemplate(code, k)
 }

--- a/internal/decoding/int.go
+++ b/internal/decoding/int.go
@@ -71,7 +71,7 @@ func (d *decoder) asInt(reader *bufio.Reader, k reflect.Kind) (int64, error) {
 		if err != nil {
 			return 0, err
 		}
-		v := binary.BigEndian.Uint16(bs)
+		v := binary.BigEndian.Uint16(bs[:])
 		return int64(v), nil
 
 	case code == def.Int16:
@@ -84,7 +84,7 @@ func (d *decoder) asInt(reader *bufio.Reader, k reflect.Kind) (int64, error) {
 		if err != nil {
 			return 0, err
 		}
-		v := int16(binary.BigEndian.Uint16(bs))
+		v := int16(binary.BigEndian.Uint16(bs[:]))
 		return int64(v), nil
 
 	case code == def.Uint32:
@@ -97,7 +97,7 @@ func (d *decoder) asInt(reader *bufio.Reader, k reflect.Kind) (int64, error) {
 		if err != nil {
 			return 0, err
 		}
-		v := binary.BigEndian.Uint32(bs)
+		v := binary.BigEndian.Uint32(bs[:])
 		return int64(v), nil
 
 	case code == def.Int32:
@@ -110,7 +110,7 @@ func (d *decoder) asInt(reader *bufio.Reader, k reflect.Kind) (int64, error) {
 		if err != nil {
 			return 0, err
 		}
-		v := int32(binary.BigEndian.Uint32(bs))
+		v := int32(binary.BigEndian.Uint32(bs[:]))
 		return int64(v), nil
 
 	case code == def.Uint64:
@@ -123,7 +123,7 @@ func (d *decoder) asInt(reader *bufio.Reader, k reflect.Kind) (int64, error) {
 		if err != nil {
 			return 0, err
 		}
-		return int64(binary.BigEndian.Uint64(bs)), nil
+		return int64(binary.BigEndian.Uint64(bs[:])), nil
 
 	case code == def.Int64:
 		err = skipOne(reader)
@@ -135,7 +135,7 @@ func (d *decoder) asInt(reader *bufio.Reader, k reflect.Kind) (int64, error) {
 		if err != nil {
 			return 0, err
 		}
-		return int64(binary.BigEndian.Uint64(bs)), nil
+		return int64(binary.BigEndian.Uint64(bs[:])), nil
 
 	case code == def.Float32:
 		v, err := d.asFloat32(reader, k)

--- a/internal/decoding/int.go
+++ b/internal/decoding/int.go
@@ -17,32 +17,19 @@ func (d *decoder) isNegativeFixNum(v byte) bool {
 }
 
 func (d *decoder) asInt(reader *bufio.Reader, k reflect.Kind) (int64, error) {
-	code, err := peekCode(reader)
+	code, err := d.readSize1(reader)
 	if err != nil {
 		return 0, err
 	}
 
 	switch {
 	case d.isPositiveFixNum(code):
-		b, err := d.readSize1(reader)
-		if err != nil {
-			return 0, err
-		}
-		return int64(b), nil
+		return int64(code), nil
 
 	case d.isNegativeFixNum(code):
-		b, err := d.readSize1(reader)
-		if err != nil {
-			return 0, err
-		}
-		return int64(int8(b)), nil
+		return int64(int8(code)), nil
 
 	case code == def.Uint8:
-		err = skipOne(reader)
-		if err != nil {
-			return 0, err
-		}
-
 		b, err := d.readSize1(reader)
 		if err != nil {
 			return 0, err
@@ -50,11 +37,6 @@ func (d *decoder) asInt(reader *bufio.Reader, k reflect.Kind) (int64, error) {
 		return int64(uint8(b)), nil
 
 	case code == def.Int8:
-		err = skipOne(reader)
-		if err != nil {
-			return 0, err
-		}
-
 		b, err := d.readSize1(reader)
 		if err != nil {
 			return 0, err
@@ -62,11 +44,6 @@ func (d *decoder) asInt(reader *bufio.Reader, k reflect.Kind) (int64, error) {
 		return int64(int8(b)), nil
 
 	case code == def.Uint16:
-		err = skipOne(reader)
-		if err != nil {
-			return 0, err
-		}
-
 		bs, err := d.readSize2(reader)
 		if err != nil {
 			return 0, err
@@ -75,11 +52,6 @@ func (d *decoder) asInt(reader *bufio.Reader, k reflect.Kind) (int64, error) {
 		return int64(v), nil
 
 	case code == def.Int16:
-		err = skipOne(reader)
-		if err != nil {
-			return 0, err
-		}
-
 		bs, err := d.readSize2(reader)
 		if err != nil {
 			return 0, err
@@ -88,11 +60,6 @@ func (d *decoder) asInt(reader *bufio.Reader, k reflect.Kind) (int64, error) {
 		return int64(v), nil
 
 	case code == def.Uint32:
-		err = skipOne(reader)
-		if err != nil {
-			return 0, err
-		}
-
 		bs, err := d.readSize4(reader)
 		if err != nil {
 			return 0, err
@@ -101,11 +68,6 @@ func (d *decoder) asInt(reader *bufio.Reader, k reflect.Kind) (int64, error) {
 		return int64(v), nil
 
 	case code == def.Int32:
-		err = skipOne(reader)
-		if err != nil {
-			return 0, err
-		}
-
 		bs, err := d.readSize4(reader)
 		if err != nil {
 			return 0, err
@@ -114,11 +76,6 @@ func (d *decoder) asInt(reader *bufio.Reader, k reflect.Kind) (int64, error) {
 		return int64(v), nil
 
 	case code == def.Uint64:
-		err = skipOne(reader)
-		if err != nil {
-			return 0, err
-		}
-
 		bs, err := d.readSize8(reader)
 		if err != nil {
 			return 0, err
@@ -126,11 +83,6 @@ func (d *decoder) asInt(reader *bufio.Reader, k reflect.Kind) (int64, error) {
 		return int64(binary.BigEndian.Uint64(bs[:])), nil
 
 	case code == def.Int64:
-		err = skipOne(reader)
-		if err != nil {
-			return 0, err
-		}
-
 		bs, err := d.readSize8(reader)
 		if err != nil {
 			return 0, err
@@ -138,14 +90,14 @@ func (d *decoder) asInt(reader *bufio.Reader, k reflect.Kind) (int64, error) {
 		return int64(binary.BigEndian.Uint64(bs[:])), nil
 
 	case code == def.Float32:
-		v, err := d.asFloat32(reader, k)
+		v, err := d.asFloat32C(reader, code, k)
 		if err != nil {
 			return 0, err
 		}
 		return int64(v), nil
 
 	case code == def.Float64:
-		v, err := d.asFloat64(reader, k)
+		v, err := d.asFloat64C(reader, code, k)
 		if err != nil {
 			return 0, err
 		}

--- a/internal/decoding/map.go
+++ b/internal/decoding/map.go
@@ -73,13 +73,13 @@ func (d *decoder) mapLength(reader *bufio.Reader, k reflect.Kind) (int, error) {
 		if err != nil {
 			return 0, err
 		}
-		return int(binary.BigEndian.Uint16(bs)), nil
+		return int(binary.BigEndian.Uint16(bs[:])), nil
 	case code == def.Map32:
 		bs, err := d.readSize4(reader)
 		if err != nil {
 			return 0, err
 		}
-		return int(binary.BigEndian.Uint32(bs)), nil
+		return int(binary.BigEndian.Uint32(bs[:])), nil
 	}
 	return 0, d.errorTemplate(code, k)
 }

--- a/internal/decoding/map.go
+++ b/internal/decoding/map.go
@@ -65,6 +65,10 @@ func (d *decoder) mapLength(reader *bufio.Reader, k reflect.Kind) (int, error) {
 		return 0, err
 	}
 
+	return d.mapLengthC(reader, code, k)
+}
+
+func (d *decoder) mapLengthC(reader *bufio.Reader, code byte, k reflect.Kind) (int, error) {
 	switch {
 	case d.isFixMap(code):
 		return int(code - def.FixMap), nil

--- a/internal/decoding/read.go
+++ b/internal/decoding/read.go
@@ -28,6 +28,15 @@ func (d *decoder) readSizeN(reader *bufio.Reader, n int) (p []byte, err error) {
 	return p, readFull(reader, p)
 }
 
+func (d *decoder) readSizeNBuf(reader *bufio.Reader, buf []byte, n int) ([]byte, error) {
+	if n > len(buf) {
+		return d.readSizeN(reader, n)
+	}
+
+	buf = buf[:n]
+	return buf, readFull(reader, buf)
+}
+
 func readFull(reader *bufio.Reader, buf []byte) (err error) {
 	for i := 0; i < len(buf); {
 		b, err := reader.Peek(len(buf)-i)

--- a/internal/decoding/read.go
+++ b/internal/decoding/read.go
@@ -48,6 +48,10 @@ func readFull(reader *bufio.Reader, buf []byte) (err error) {
 
 		i += len(b)
 		_, err = reader.Discard(len(b))
+		if err != nil {
+			return err
+		}
 	}
-	return err
+
+	return nil
 }

--- a/internal/decoding/read.go
+++ b/internal/decoding/read.go
@@ -39,7 +39,7 @@ func (d *decoder) readSizeNBuf(reader *bufio.Reader, buf []byte, n int) ([]byte,
 
 func readFull(reader *bufio.Reader, buf []byte) (err error) {
 	for i := 0; i < len(buf); {
-		b, err := reader.Peek(len(buf)-i)
+		b, err := reader.Peek(len(buf) - i)
 		if err != nil && !errors.Is(err, bufio.ErrBufferFull) {
 			return err
 		}

--- a/internal/decoding/read.go
+++ b/internal/decoding/read.go
@@ -1,29 +1,48 @@
 package decoding
 
 import (
+	"bufio"
+	"io"
+
 	"github.com/shamaton/msgpack/v2/def"
 )
 
-func (d *decoder) readSize1(index int) (byte, int) {
-	rb := def.Byte1
-	return d.data[index], index + rb
+func (d *decoder) readSize1(reader *bufio.Reader) (byte, error) {
+	return reader.ReadByte()
 }
 
-func (d *decoder) readSize2(index int) ([]byte, int) {
-	rb := def.Byte2
-	return d.data[index : index+rb], index + rb
+func (d *decoder) readSize2(reader *bufio.Reader) ([]byte, error) {
+	p := make([]byte, def.Byte2)
+	_, err := io.ReadFull(reader, p)
+	if err != nil {
+		return nil, err
+	}
+	return p, nil
 }
 
-func (d *decoder) readSize4(index int) ([]byte, int) {
-	rb := def.Byte4
-	return d.data[index : index+rb], index + rb
+func (d *decoder) readSize4(reader *bufio.Reader) ([]byte, error) {
+	p := make([]byte, def.Byte4)
+	_, err := io.ReadFull(reader, p)
+	if err != nil {
+		return nil, err
+	}
+	return p, nil
 }
 
-func (d *decoder) readSize8(index int) ([]byte, int) {
-	rb := def.Byte8
-	return d.data[index : index+rb], index + rb
+func (d *decoder) readSize8(reader *bufio.Reader) ([]byte, error) {
+	p := make([]byte, def.Byte8)
+	_, err := io.ReadFull(reader, p)
+	if err != nil {
+		return nil, err
+	}
+	return p, nil
 }
 
-func (d *decoder) readSizeN(index, n int) ([]byte, int) {
-	return d.data[index : index+n], index + n
+func (d *decoder) readSizeN(reader *bufio.Reader, n int) ([]byte, error) {
+	p := make([]byte, n)
+	_, err := io.ReadFull(reader, p)
+	if err != nil {
+		return nil, err
+	}
+	return p, nil
 }

--- a/internal/decoding/read.go
+++ b/internal/decoding/read.go
@@ -24,12 +24,18 @@ func (d *decoder) readSize8(reader *bufio.Reader) (p [def.Byte8]byte, err error)
 }
 
 func (d *decoder) readSizeN(reader *bufio.Reader, n int) (p []byte, err error) {
+	if n == 0 {
+		return nil, nil
+	}
+
 	p = make([]byte, n)
 	return p, readFull(reader, p)
 }
 
 func (d *decoder) readSizeNBuf(reader *bufio.Reader, buf []byte, n int) ([]byte, error) {
-	if n > len(buf) {
+	if n == 0 {
+		return nil, nil
+	} else if n > len(buf) {
 		return d.readSizeN(reader, n)
 	}
 

--- a/internal/decoding/slice.go
+++ b/internal/decoding/slice.go
@@ -47,13 +47,13 @@ func (d *decoder) sliceLength(reader *bufio.Reader, k reflect.Kind) (int, error)
 		if err != nil {
 			return 0, err
 		}
-		return int(binary.BigEndian.Uint16(bs)), nil
+		return int(binary.BigEndian.Uint16(bs[:])), nil
 	case code == def.Array32:
 		bs, err := d.readSize4(reader)
 		if err != nil {
 			return 0, err
 		}
-		return int(binary.BigEndian.Uint32(bs)), nil
+		return int(binary.BigEndian.Uint32(bs[:])), nil
 	}
 	return 0, d.errorTemplate(code, k)
 }

--- a/internal/decoding/slice.go
+++ b/internal/decoding/slice.go
@@ -39,6 +39,10 @@ func (d *decoder) sliceLength(reader *bufio.Reader, k reflect.Kind) (int, error)
 		return 0, err
 	}
 
+	return d.sliceLengthC(reader, code, k)
+}
+
+func (d *decoder) sliceLengthC(reader *bufio.Reader, code byte, k reflect.Kind) (int, error) {
 	switch {
 	case d.isFixSlice(code):
 		return int(code - def.FixArray), nil

--- a/internal/decoding/string.go
+++ b/internal/decoding/string.go
@@ -86,7 +86,6 @@ func (d *decoder) asStringByteC(reader *bufio.Reader, code byte, buf []byte, k r
 	return d.readSizeNBuf(reader, buf, l)
 }
 
-
 func (d *decoder) asStringByte(reader *bufio.Reader, buf []byte, k reflect.Kind) ([]byte, error) {
 	code, err := reader.ReadByte()
 	if err != nil {

--- a/internal/decoding/string.go
+++ b/internal/decoding/string.go
@@ -5,6 +5,7 @@ import (
 	"encoding/binary"
 	"reflect"
 
+	"github.com/josharian/intern"
 	"github.com/shamaton/msgpack/v2/def"
 )
 
@@ -70,7 +71,7 @@ func (d *decoder) asString(reader *bufio.Reader, k reflect.Kind) (string, error)
 		return emptyString, err
 	}
 
-	return string(bs), nil
+	return d.maybeInternString(bs), nil
 }
 
 func (d *decoder) asStringByteC(reader *bufio.Reader, code byte, buf []byte, k reflect.Kind) ([]byte, error) {
@@ -94,4 +95,13 @@ func (d *decoder) asStringByte(reader *bufio.Reader, buf []byte, k reflect.Kind)
 	}
 
 	return d.asStringByteC(reader, code, buf, k)
+}
+
+// this is inlined everywhere that it is used, appears to have no performance impact when internStrings == false
+func (d *decoder) maybeInternString(bs []byte) string {
+	if d.internStrings {
+		return intern.Bytes(bs)
+	}
+
+	return string(bs)
 }

--- a/internal/decoding/string.go
+++ b/internal/decoding/string.go
@@ -19,15 +19,6 @@ func (d *decoder) isFixString(v byte) bool {
 	return def.FixStr <= v && v <= def.FixStr+0x1f
 }
 
-func (d *decoder) stringByteLength(reader *bufio.Reader, k reflect.Kind) (int, error) {
-	code, err := reader.ReadByte()
-	if err != nil {
-		return 0, err
-	}
-
-	return d.stringByteLengthC(reader, code, k)
-}
-
 func (d *decoder) stringByteLengthC(reader *bufio.Reader, code byte, k reflect.Kind) (int, error) {
 	if def.FixStr <= code && code <= def.FixStr+0x1f {
 		l := int(code - def.FixStr)

--- a/internal/decoding/string.go
+++ b/internal/decoding/string.go
@@ -41,14 +41,14 @@ func (d *decoder) stringByteLength(reader *bufio.Reader, k reflect.Kind) (int, e
 			return 0, err
 		}
 
-		return int(binary.BigEndian.Uint16(b)), nil
+		return int(binary.BigEndian.Uint16(b[:])), nil
 	} else if code == def.Str32 {
 		b, err := d.readSize4(reader)
 		if err != nil {
 			return 0, err
 		}
 
-		return int(binary.BigEndian.Uint32(b)), nil
+		return int(binary.BigEndian.Uint32(b[:])), nil
 	} else if code == def.Nil {
 		return 0, nil
 	}

--- a/internal/decoding/string.go
+++ b/internal/decoding/string.go
@@ -5,7 +5,6 @@ import (
 	"encoding/binary"
 	"reflect"
 
-	"github.com/josharian/intern"
 	"github.com/shamaton/msgpack/v2/def"
 )
 
@@ -99,8 +98,14 @@ func (d *decoder) asStringByte(reader *bufio.Reader, buf []byte, k reflect.Kind)
 
 // this is inlined everywhere that it is used, appears to have no performance impact when internStrings == false
 func (d *decoder) maybeInternString(bs []byte) string {
-	if d.internStrings {
-		return intern.Bytes(bs)
+	if d.internStrings != nil {
+		if s, ok := d.internStrings[string(bs)]; ok {
+			return s
+		}
+
+		s := string(bs)
+		d.internStrings[s] = s
+		return s
 	}
 
 	return string(bs)

--- a/internal/decoding/struct.go
+++ b/internal/decoding/struct.go
@@ -3,8 +3,9 @@ package decoding
 import (
 	"bufio"
 	"encoding/binary"
-	"fmt"
+	"errors"
 	"reflect"
+	"strconv"
 	"sync"
 
 	"github.com/shamaton/msgpack/v2/def"
@@ -208,7 +209,7 @@ func (d *decoder) jumpOffset(reader *bufio.Reader) error {
 			return err
 		}
 
-		err = skipN(reader, int(binary.BigEndian.Uint16(bs)))
+		err = skipN(reader, int(binary.BigEndian.Uint16(bs[:])))
 		if err != nil {
 			return err
 		}
@@ -218,7 +219,7 @@ func (d *decoder) jumpOffset(reader *bufio.Reader) error {
 			return err
 		}
 
-		err = skipN(reader, int(binary.BigEndian.Uint32(bs)))
+		err = skipN(reader, int(binary.BigEndian.Uint32(bs[:])))
 		if err != nil {
 			return err
 		}
@@ -236,7 +237,7 @@ func (d *decoder) jumpOffset(reader *bufio.Reader) error {
 		if err != nil {
 			return err
 		}
-		l := int(binary.BigEndian.Uint16(bs))
+		l := int(binary.BigEndian.Uint16(bs[:]))
 		for i := 0; i < l; i++ {
 			err = d.jumpOffset(reader)
 			if err != nil {
@@ -248,7 +249,7 @@ func (d *decoder) jumpOffset(reader *bufio.Reader) error {
 		if err != nil {
 			return err
 		}
-		l := int(binary.BigEndian.Uint32(bs))
+		l := int(binary.BigEndian.Uint32(bs[:]))
 		for i := 0; i < l; i++ {
 			err = d.jumpOffset(reader)
 			if err != nil {
@@ -269,7 +270,7 @@ func (d *decoder) jumpOffset(reader *bufio.Reader) error {
 		if err != nil {
 			return err
 		}
-		l := int(binary.BigEndian.Uint16(bs))
+		l := int(binary.BigEndian.Uint16(bs[:]))
 		for i := 0; i < l*2; i++ {
 			err = d.jumpOffset(reader)
 			if err != nil {
@@ -281,7 +282,7 @@ func (d *decoder) jumpOffset(reader *bufio.Reader) error {
 		if err != nil {
 			return err
 		}
-		l := int(binary.BigEndian.Uint32(bs))
+		l := int(binary.BigEndian.Uint32(bs[:]))
 		for i := 0; i < l*2; i++ {
 			err = d.jumpOffset(reader)
 			if err != nil {
@@ -331,7 +332,7 @@ func (d *decoder) jumpOffset(reader *bufio.Reader) error {
 			return err
 		}
 
-		err = skipN(reader, def.Byte1+int(binary.BigEndian.Uint16(bs)))
+		err = skipN(reader, def.Byte1+int(binary.BigEndian.Uint16(bs[:])))
 		if err != nil {
 			return err
 		}
@@ -341,13 +342,13 @@ func (d *decoder) jumpOffset(reader *bufio.Reader) error {
 			return err
 		}
 
-		err = skipN(reader, def.Byte1+int(binary.BigEndian.Uint32(bs)))
+		err = skipN(reader, def.Byte1+int(binary.BigEndian.Uint32(bs[:])))
 		if err != nil {
 			return err
 		}
 
 	default:
-		return fmt.Errorf("unrecognized code: %d", code)
+		return errors.New("unrecognized code: " + strconv.FormatInt(int64(code), 16))
 
 	}
 

--- a/internal/decoding/struct.go
+++ b/internal/decoding/struct.go
@@ -67,6 +67,10 @@ func (d *decoder) setStructFromArray(rv reflect.Value, reader *bufio.Reader, k r
 		return err
 	}
 
+	if l == 0 {
+		return nil
+	}
+
 	// find or create reference
 	var scta *structCacheTypeArray
 	cache, findCache := mapSCTA.Load(rv.Type())
@@ -103,6 +107,10 @@ func (d *decoder) setStructFromMap(rv reflect.Value, reader *bufio.Reader, k ref
 	l, err := d.mapLength(reader, k)
 	if err != nil {
 		return err
+	}
+
+	if l == 0 {
+		return nil
 	}
 
 	var sctm *structCacheTypeMap

--- a/internal/decoding/struct.go
+++ b/internal/decoding/struct.go
@@ -89,7 +89,10 @@ func (d *decoder) setStructFromArray(rv reflect.Value, reader *bufio.Reader, k r
 				return err
 			}
 		} else {
-			d.jumpOffset(reader)
+			err = d.jumpOffset(reader)
+			if err != nil {
+				return err
+			}
 		}
 	}
 	return nil

--- a/internal/decoding/struct.go
+++ b/internal/decoding/struct.go
@@ -1,7 +1,9 @@
 package decoding
 
 import (
+	"bufio"
 	"encoding/binary"
+	"fmt"
 	"reflect"
 	"sync"
 
@@ -21,9 +23,9 @@ type structCacheTypeArray struct {
 var mapSCTM = sync.Map{}
 var mapSCTA = sync.Map{}
 
-func (d *decoder) setStruct(rv reflect.Value, offset int, k reflect.Kind) (int, error) {
+func (d *decoder) setStruct(rv reflect.Value, reader *bufio.Reader, k reflect.Kind) error {
 	/*
-		if d.isDateTime(offset) {
+		if d.isDateTime(reader) {
 			dt, offset, err := d.asDateTime(offset, k)
 			if err != nil {
 				return 0, err
@@ -33,32 +35,34 @@ func (d *decoder) setStruct(rv reflect.Value, offset int, k reflect.Kind) (int, 
 		}
 	*/
 
-	for i := range extCoders {
-		if extCoders[i].IsType(offset, &d.data) {
-			v, offset, err := extCoders[i].AsValue(offset, k, &d.data)
-			if err != nil {
-				return 0, err
-			}
+	if code, data, err := d.readExt(reader); err == nil {
+		for i := range extCoders {
+			if extCoders[i].Code() == int8(code) {
+				v, err := extCoders[i].AsValue(data, k)
+				if err != nil {
+					return err
+				}
 
-			// Validate that the receptacle is of the right value type.
-			if rv.Type() == reflect.TypeOf(v) {
-				rv.Set(reflect.ValueOf(v))
-				return offset, nil
+				// Validate that the receptacle is of the right value type.
+				if rv.Type() == reflect.TypeOf(v) {
+					rv.Set(reflect.ValueOf(v))
+					return nil
+				}
 			}
 		}
 	}
 
 	if d.asArray {
-		return d.setStructFromArray(rv, offset, k)
+		return d.setStructFromArray(rv, reader, k)
 	}
-	return d.setStructFromMap(rv, offset, k)
+	return d.setStructFromMap(rv, reader, k)
 }
 
-func (d *decoder) setStructFromArray(rv reflect.Value, offset int, k reflect.Kind) (int, error) {
+func (d *decoder) setStructFromArray(rv reflect.Value, reader *bufio.Reader, k reflect.Kind) error {
 	// get length
-	l, o, err := d.sliceLength(offset, k)
+	l, err := d.sliceLength(reader, k)
 	if err != nil {
-		return 0, err
+		return err
 	}
 
 	// find or create reference
@@ -78,22 +82,22 @@ func (d *decoder) setStructFromArray(rv reflect.Value, offset int, k reflect.Kin
 	// set value
 	for i := 0; i < l; i++ {
 		if i < len(scta.m) {
-			o, err = d.decode(rv.Field(scta.m[i]), o)
+			err = d.decode(rv.Field(scta.m[i]), reader)
 			if err != nil {
-				return 0, err
+				return err
 			}
 		} else {
-			o = d.jumpOffset(o)
+			d.jumpOffset(reader)
 		}
 	}
-	return o, nil
+	return nil
 }
 
-func (d *decoder) setStructFromMap(rv reflect.Value, offset int, k reflect.Kind) (int, error) {
+func (d *decoder) setStructFromMap(rv reflect.Value, reader *bufio.Reader, k reflect.Kind) error {
 	// get length
-	l, o, err := d.mapLength(offset, k)
+	l, err := d.mapLength(reader, k)
 	if err != nil {
-		return 0, err
+		return err
 	}
 
 	var sctm *structCacheTypeMap
@@ -112,9 +116,9 @@ func (d *decoder) setStructFromMap(rv reflect.Value, offset int, k reflect.Kind)
 	}
 
 	for i := 0; i < l; i++ {
-		dataKey, o2, err := d.asStringByte(o, k)
+		dataKey, err := d.asStringByte(reader, k)
 		if err != nil {
-			return 0, err
+			return err
 		}
 
 		fieldIndex := -1
@@ -136,20 +140,26 @@ func (d *decoder) setStructFromMap(rv reflect.Value, offset int, k reflect.Kind)
 		}
 
 		if fieldIndex >= 0 {
-			o2, err = d.decode(rv.Field(fieldIndex), o2)
+			err = d.decode(rv.Field(fieldIndex), reader)
 			if err != nil {
-				return 0, err
+				return err
 			}
 		} else {
-			o2 = d.jumpOffset(o2)
+			err = d.jumpOffset(reader)
+			if err != nil {
+				return err
+			}
 		}
-		o = o2
 	}
-	return o, nil
+	return nil
 }
 
-func (d *decoder) jumpOffset(offset int) int {
-	code, offset := d.readSize1(offset)
+func (d *decoder) jumpOffset(reader *bufio.Reader) error {
+	code, err := reader.ReadByte()
+	if err != nil {
+		return err
+	}
+
 	switch {
 	case code == def.True, code == def.False, code == def.Nil:
 		// do nothing
@@ -157,93 +167,189 @@ func (d *decoder) jumpOffset(offset int) int {
 	case d.isPositiveFixNum(code) || d.isNegativeFixNum(code):
 		// do nothing
 	case code == def.Uint8, code == def.Int8:
-		offset += def.Byte1
+		err = skipN(reader, def.Byte1)
+		if err != nil {
+			return err
+		}
 	case code == def.Uint16, code == def.Int16:
-		offset += def.Byte2
+		err = skipN(reader, def.Byte2)
+		if err != nil {
+			return err
+		}
 	case code == def.Uint32, code == def.Int32, code == def.Float32:
-		offset += def.Byte4
+		err = skipN(reader, def.Byte4)
+		if err != nil {
+			return err
+		}
 	case code == def.Uint64, code == def.Int64, code == def.Float64:
-		offset += def.Byte8
+		err = skipN(reader, def.Byte8)
+		if err != nil {
+			return err
+		}
 
 	case d.isFixString(code):
-		offset += int(code - def.FixStr)
+		err = skipN(reader, int(code - def.FixStr))
+		if err != nil {
+			return err
+		}
 	case code == def.Str8, code == def.Bin8:
-		b, o := d.readSize1(offset)
-		o += int(b)
-		offset = o
+		b, err := d.readSize1(reader)
+		if err != nil {
+			return err
+		}
+
+		err = skipN(reader, int(b))
+		if err != nil {
+			return err
+		}
 	case code == def.Str16, code == def.Bin16:
-		bs, o := d.readSize2(offset)
-		o += int(binary.BigEndian.Uint16(bs))
-		offset = o
+		bs, err := d.readSize2(reader)
+		if err != nil {
+			return err
+		}
+
+		err = skipN(reader, int(binary.BigEndian.Uint16(bs)))
+		if err != nil {
+			return err
+		}
 	case code == def.Str32, code == def.Bin32:
-		bs, o := d.readSize4(offset)
-		o += int(binary.BigEndian.Uint32(bs))
-		offset = o
+		bs, err := d.readSize4(reader)
+		if err != nil {
+			return err
+		}
+
+		err = skipN(reader, int(binary.BigEndian.Uint32(bs)))
+		if err != nil {
+			return err
+		}
 
 	case d.isFixSlice(code):
 		l := int(code - def.FixArray)
 		for i := 0; i < l; i++ {
-			offset = d.jumpOffset(offset)
+			err = d.jumpOffset(reader)
+			if err != nil {
+				return err
+			}
 		}
 	case code == def.Array16:
-		bs, o := d.readSize2(offset)
+		bs, err := d.readSize2(reader)
+		if err != nil {
+			return err
+		}
 		l := int(binary.BigEndian.Uint16(bs))
 		for i := 0; i < l; i++ {
-			o = d.jumpOffset(o)
+			err = d.jumpOffset(reader)
+			if err != nil {
+				return err
+			}
 		}
-		offset = o
 	case code == def.Array32:
-		bs, o := d.readSize4(offset)
+		bs, err := d.readSize4(reader)
+		if err != nil {
+			return err
+		}
 		l := int(binary.BigEndian.Uint32(bs))
 		for i := 0; i < l; i++ {
-			o = d.jumpOffset(o)
+			err = d.jumpOffset(reader)
+			if err != nil {
+				return err
+			}
 		}
-		offset = o
 
 	case d.isFixMap(code):
 		l := int(code - def.FixMap)
 		for i := 0; i < l*2; i++ {
-			offset = d.jumpOffset(offset)
+			err = d.jumpOffset(reader)
+			if err != nil {
+				return err
+			}
 		}
 	case code == def.Map16:
-		bs, o := d.readSize2(offset)
+		bs, err := d.readSize2(reader)
+		if err != nil {
+			return err
+		}
 		l := int(binary.BigEndian.Uint16(bs))
 		for i := 0; i < l*2; i++ {
-			o = d.jumpOffset(o)
+			err = d.jumpOffset(reader)
+			if err != nil {
+				return err
+			}
 		}
-		offset = o
 	case code == def.Map32:
-		bs, o := d.readSize4(offset)
+		bs, err := d.readSize4(reader)
+		if err != nil {
+			return err
+		}
 		l := int(binary.BigEndian.Uint32(bs))
 		for i := 0; i < l*2; i++ {
-			o = d.jumpOffset(o)
+			err = d.jumpOffset(reader)
+			if err != nil {
+				return err
+			}
 		}
-		offset = o
 
 	case code == def.Fixext1:
-		offset += def.Byte1 + def.Byte1
+		err = skipN(reader, def.Byte1 + def.Byte1)
+		if err != nil {
+			return err
+		}
 	case code == def.Fixext2:
-		offset += def.Byte1 + def.Byte2
+		err = skipN(reader, def.Byte1 + def.Byte2)
+		if err != nil {
+			return err
+		}
 	case code == def.Fixext4:
-		offset += def.Byte1 + def.Byte4
+		err = skipN(reader, def.Byte1 + def.Byte4)
+		if err != nil {
+			return err
+		}
 	case code == def.Fixext8:
-		offset += def.Byte1 + def.Byte8
+		err = skipN(reader, def.Byte1 + def.Byte8)
+		if err != nil {
+			return err
+		}
 	case code == def.Fixext16:
-		offset += def.Byte1 + def.Byte16
+		err = skipN(reader, def.Byte1 + def.Byte16)
+		if err != nil {
+			return err
+		}
 
 	case code == def.Ext8:
-		b, o := d.readSize1(offset)
-		o += def.Byte1 + int(b)
-		offset = o
+		b, err := d.readSize1(reader)
+		if err != nil {
+			return err
+		}
+
+		err = skipN(reader, def.Byte1 + int(b))
+		if err != nil {
+			return err
+		}
 	case code == def.Ext16:
-		bs, o := d.readSize2(offset)
-		o += def.Byte1 + int(binary.BigEndian.Uint16(bs))
-		offset = o
+		bs, err := d.readSize2(reader)
+		if err != nil {
+			return err
+		}
+
+		err = skipN(reader, def.Byte1 + int(binary.BigEndian.Uint16(bs)))
+		if err != nil {
+			return err
+		}
 	case code == def.Ext32:
-		bs, o := d.readSize4(offset)
-		o += def.Byte1 + int(binary.BigEndian.Uint32(bs))
-		offset = o
+		bs, err := d.readSize4(reader)
+		if err != nil {
+			return err
+		}
+
+		err = skipN(reader, def.Byte1 + int(binary.BigEndian.Uint32(bs)))
+		if err != nil {
+			return err
+		}
+
+	default:
+		return fmt.Errorf("unrecognized code: %d", code)
 
 	}
-	return offset
+
+	return nil
 }

--- a/internal/decoding/struct.go
+++ b/internal/decoding/struct.go
@@ -126,7 +126,7 @@ func (d *decoder) setStructFromMap(rv reflect.Value, reader *bufio.Reader, k ref
 
 		fieldIndex := -1
 		for keyIndex, keyBytes := range sctm.keys {
-			if !bytes.Equal(keyBytes, dataKey){
+			if !bytes.Equal(keyBytes, dataKey) {
 				continue
 			}
 

--- a/internal/decoding/struct.go
+++ b/internal/decoding/struct.go
@@ -2,6 +2,7 @@ package decoding
 
 import (
 	"bufio"
+	"bytes"
 	"encoding/binary"
 	"errors"
 	"reflect"
@@ -116,25 +117,20 @@ func (d *decoder) setStructFromMap(rv reflect.Value, reader *bufio.Reader, k ref
 		sctm = cache.(*structCacheTypeMap)
 	}
 
+	keyBuf := make([]byte, 32)
 	for i := 0; i < l; i++ {
-		dataKey, err := d.asStringByte(reader, k)
+		dataKey, err := d.asStringByte(reader, keyBuf, k)
 		if err != nil {
 			return err
 		}
 
 		fieldIndex := -1
 		for keyIndex, keyBytes := range sctm.keys {
-			if len(keyBytes) != len(dataKey) {
+			if !bytes.Equal(keyBytes, dataKey){
 				continue
 			}
 
 			fieldIndex = sctm.indexes[keyIndex]
-			for dataIndex := range dataKey {
-				if dataKey[dataIndex] != keyBytes[dataIndex] {
-					fieldIndex = -1
-					break
-				}
-			}
 			if fieldIndex >= 0 {
 				break
 			}

--- a/internal/decoding/struct.go
+++ b/internal/decoding/struct.go
@@ -188,7 +188,7 @@ func (d *decoder) jumpOffset(reader *bufio.Reader) error {
 		}
 
 	case d.isFixString(code):
-		err = skipN(reader, int(code - def.FixStr))
+		err = skipN(reader, int(code-def.FixStr))
 		if err != nil {
 			return err
 		}
@@ -290,27 +290,27 @@ func (d *decoder) jumpOffset(reader *bufio.Reader) error {
 		}
 
 	case code == def.Fixext1:
-		err = skipN(reader, def.Byte1 + def.Byte1)
+		err = skipN(reader, def.Byte1+def.Byte1)
 		if err != nil {
 			return err
 		}
 	case code == def.Fixext2:
-		err = skipN(reader, def.Byte1 + def.Byte2)
+		err = skipN(reader, def.Byte1+def.Byte2)
 		if err != nil {
 			return err
 		}
 	case code == def.Fixext4:
-		err = skipN(reader, def.Byte1 + def.Byte4)
+		err = skipN(reader, def.Byte1+def.Byte4)
 		if err != nil {
 			return err
 		}
 	case code == def.Fixext8:
-		err = skipN(reader, def.Byte1 + def.Byte8)
+		err = skipN(reader, def.Byte1+def.Byte8)
 		if err != nil {
 			return err
 		}
 	case code == def.Fixext16:
-		err = skipN(reader, def.Byte1 + def.Byte16)
+		err = skipN(reader, def.Byte1+def.Byte16)
 		if err != nil {
 			return err
 		}
@@ -321,7 +321,7 @@ func (d *decoder) jumpOffset(reader *bufio.Reader) error {
 			return err
 		}
 
-		err = skipN(reader, def.Byte1 + int(b))
+		err = skipN(reader, def.Byte1+int(b))
 		if err != nil {
 			return err
 		}
@@ -331,7 +331,7 @@ func (d *decoder) jumpOffset(reader *bufio.Reader) error {
 			return err
 		}
 
-		err = skipN(reader, def.Byte1 + int(binary.BigEndian.Uint16(bs)))
+		err = skipN(reader, def.Byte1+int(binary.BigEndian.Uint16(bs)))
 		if err != nil {
 			return err
 		}
@@ -341,7 +341,7 @@ func (d *decoder) jumpOffset(reader *bufio.Reader) error {
 			return err
 		}
 
-		err = skipN(reader, def.Byte1 + int(binary.BigEndian.Uint32(bs)))
+		err = skipN(reader, def.Byte1+int(binary.BigEndian.Uint32(bs)))
 		if err != nil {
 			return err
 		}

--- a/internal/decoding/uint.go
+++ b/internal/decoding/uint.go
@@ -1,73 +1,137 @@
 package decoding
 
 import (
+	"bufio"
 	"encoding/binary"
 	"reflect"
 
 	"github.com/shamaton/msgpack/v2/def"
 )
 
-func (d *decoder) asUint(offset int, k reflect.Kind) (uint64, int, error) {
-
-	code := d.data[offset]
+func (d *decoder) asUint(reader *bufio.Reader, k reflect.Kind) (uint64, error) {
+	code, err := peekCode(reader)
+	if err != nil {
+		return 0, err
+	}
 
 	switch {
 	case d.isPositiveFixNum(code):
-		b, offset := d.readSize1(offset)
-		return uint64(b), offset, nil
+		b, err := d.readSize1(reader)
+		if err != nil {
+			return 0, err
+		}
+		return uint64(b), nil
 
 	case d.isNegativeFixNum(code):
-		b, offset := d.readSize1(offset)
-		return uint64(int8(b)), offset, nil
+		b, err := d.readSize1(reader)
+		if err != nil {
+			return 0, err
+		}
+		return uint64(int8(b)), nil
 
 	case code == def.Uint8:
-		offset++
-		b, offset := d.readSize1(offset)
-		return uint64(uint8(b)), offset, nil
+		err = skipOne(reader)
+		if err != nil {
+			return 0, err
+		}
+
+		b, err := d.readSize1(reader)
+		if err != nil {
+			return 0, err
+		}
+		return uint64(uint8(b)), nil
 
 	case code == def.Int8:
-		offset++
-		b, offset := d.readSize1(offset)
-		return uint64(int8(b)), offset, nil
+		err = skipOne(reader)
+		if err != nil {
+			return 0, err
+		}
+
+		b, err := d.readSize1(reader)
+		if err != nil {
+			return 0, err
+		}
+		return uint64(int8(b)), nil
 
 	case code == def.Uint16:
-		offset++
-		bs, offset := d.readSize2(offset)
+		err = skipOne(reader)
+		if err != nil {
+			return 0, err
+		}
+
+		bs, err := d.readSize2(reader)
+		if err != nil {
+			return 0, err
+		}
 		v := binary.BigEndian.Uint16(bs)
-		return uint64(v), offset, nil
+		return uint64(v), nil
 
 	case code == def.Int16:
-		offset++
-		bs, offset := d.readSize2(offset)
+		err = skipOne(reader)
+		if err != nil {
+			return 0, err
+		}
+
+		bs, err := d.readSize2(reader)
+		if err != nil {
+			return 0, err
+		}
 		v := int16(binary.BigEndian.Uint16(bs))
-		return uint64(v), offset, nil
+		return uint64(v), nil
 
 	case code == def.Uint32:
-		offset++
-		bs, offset := d.readSize4(offset)
+		err = skipOne(reader)
+		if err != nil {
+			return 0, err
+		}
+
+		bs, err := d.readSize4(reader)
+		if err != nil {
+			return 0, err
+		}
 		v := binary.BigEndian.Uint32(bs)
-		return uint64(v), offset, nil
+		return uint64(v), nil
 
 	case code == def.Int32:
-		offset++
-		bs, offset := d.readSize4(offset)
+		err = skipOne(reader)
+		if err != nil {
+			return 0, err
+		}
+
+		bs, err := d.readSize4(reader)
+		if err != nil {
+			return 0, err
+		}
 		v := int32(binary.BigEndian.Uint32(bs))
-		return uint64(v), offset, nil
+		return uint64(v), nil
 
 	case code == def.Uint64:
-		offset++
-		bs, offset := d.readSize8(offset)
-		return binary.BigEndian.Uint64(bs), offset, nil
+		err = skipOne(reader)
+		if err != nil {
+			return 0, err
+		}
+
+		bs, err := d.readSize8(reader)
+		if err != nil {
+			return 0, err
+		}
+		return binary.BigEndian.Uint64(bs), nil
 
 	case code == def.Int64:
-		offset++
-		bs, offset := d.readSize8(offset)
-		return binary.BigEndian.Uint64(bs), offset, nil
+		err = skipOne(reader)
+		if err != nil {
+			return 0, err
+		}
+
+		bs, err := d.readSize8(reader)
+		if err != nil {
+			return 0, err
+		}
+		return binary.BigEndian.Uint64(bs), nil
 
 	case code == def.Nil:
-		offset++
-		return 0, offset, nil
+		return 0, skipOne(reader)
 	}
 
-	return 0, 0, d.errorTemplate(code, k)
+	return 0, d.errorTemplate(code, k)
 }

--- a/internal/decoding/uint.go
+++ b/internal/decoding/uint.go
@@ -63,7 +63,7 @@ func (d *decoder) asUint(reader *bufio.Reader, k reflect.Kind) (uint64, error) {
 		if err != nil {
 			return 0, err
 		}
-		v := binary.BigEndian.Uint16(bs)
+		v := binary.BigEndian.Uint16(bs[:])
 		return uint64(v), nil
 
 	case code == def.Int16:
@@ -76,7 +76,7 @@ func (d *decoder) asUint(reader *bufio.Reader, k reflect.Kind) (uint64, error) {
 		if err != nil {
 			return 0, err
 		}
-		v := int16(binary.BigEndian.Uint16(bs))
+		v := int16(binary.BigEndian.Uint16(bs[:]))
 		return uint64(v), nil
 
 	case code == def.Uint32:
@@ -89,7 +89,7 @@ func (d *decoder) asUint(reader *bufio.Reader, k reflect.Kind) (uint64, error) {
 		if err != nil {
 			return 0, err
 		}
-		v := binary.BigEndian.Uint32(bs)
+		v := binary.BigEndian.Uint32(bs[:])
 		return uint64(v), nil
 
 	case code == def.Int32:
@@ -102,7 +102,7 @@ func (d *decoder) asUint(reader *bufio.Reader, k reflect.Kind) (uint64, error) {
 		if err != nil {
 			return 0, err
 		}
-		v := int32(binary.BigEndian.Uint32(bs))
+		v := int32(binary.BigEndian.Uint32(bs[:]))
 		return uint64(v), nil
 
 	case code == def.Uint64:
@@ -115,7 +115,7 @@ func (d *decoder) asUint(reader *bufio.Reader, k reflect.Kind) (uint64, error) {
 		if err != nil {
 			return 0, err
 		}
-		return binary.BigEndian.Uint64(bs), nil
+		return binary.BigEndian.Uint64(bs[:]), nil
 
 	case code == def.Int64:
 		err = skipOne(reader)
@@ -127,7 +127,7 @@ func (d *decoder) asUint(reader *bufio.Reader, k reflect.Kind) (uint64, error) {
 		if err != nil {
 			return 0, err
 		}
-		return binary.BigEndian.Uint64(bs), nil
+		return binary.BigEndian.Uint64(bs[:]), nil
 
 	case code == def.Nil:
 		return 0, skipOne(reader)

--- a/internal/decoding/uint.go
+++ b/internal/decoding/uint.go
@@ -9,32 +9,19 @@ import (
 )
 
 func (d *decoder) asUint(reader *bufio.Reader, k reflect.Kind) (uint64, error) {
-	code, err := peekCode(reader)
+	code, err := d.readSize1(reader)
 	if err != nil {
 		return 0, err
 	}
 
 	switch {
 	case d.isPositiveFixNum(code):
-		b, err := d.readSize1(reader)
-		if err != nil {
-			return 0, err
-		}
-		return uint64(b), nil
+		return uint64(code), nil
 
 	case d.isNegativeFixNum(code):
-		b, err := d.readSize1(reader)
-		if err != nil {
-			return 0, err
-		}
-		return uint64(int8(b)), nil
+		return uint64(int8(code)), nil
 
 	case code == def.Uint8:
-		err = skipOne(reader)
-		if err != nil {
-			return 0, err
-		}
-
 		b, err := d.readSize1(reader)
 		if err != nil {
 			return 0, err
@@ -42,11 +29,6 @@ func (d *decoder) asUint(reader *bufio.Reader, k reflect.Kind) (uint64, error) {
 		return uint64(uint8(b)), nil
 
 	case code == def.Int8:
-		err = skipOne(reader)
-		if err != nil {
-			return 0, err
-		}
-
 		b, err := d.readSize1(reader)
 		if err != nil {
 			return 0, err
@@ -54,11 +36,6 @@ func (d *decoder) asUint(reader *bufio.Reader, k reflect.Kind) (uint64, error) {
 		return uint64(int8(b)), nil
 
 	case code == def.Uint16:
-		err = skipOne(reader)
-		if err != nil {
-			return 0, err
-		}
-
 		bs, err := d.readSize2(reader)
 		if err != nil {
 			return 0, err
@@ -67,11 +44,6 @@ func (d *decoder) asUint(reader *bufio.Reader, k reflect.Kind) (uint64, error) {
 		return uint64(v), nil
 
 	case code == def.Int16:
-		err = skipOne(reader)
-		if err != nil {
-			return 0, err
-		}
-
 		bs, err := d.readSize2(reader)
 		if err != nil {
 			return 0, err
@@ -80,11 +52,6 @@ func (d *decoder) asUint(reader *bufio.Reader, k reflect.Kind) (uint64, error) {
 		return uint64(v), nil
 
 	case code == def.Uint32:
-		err = skipOne(reader)
-		if err != nil {
-			return 0, err
-		}
-
 		bs, err := d.readSize4(reader)
 		if err != nil {
 			return 0, err
@@ -93,11 +60,6 @@ func (d *decoder) asUint(reader *bufio.Reader, k reflect.Kind) (uint64, error) {
 		return uint64(v), nil
 
 	case code == def.Int32:
-		err = skipOne(reader)
-		if err != nil {
-			return 0, err
-		}
-
 		bs, err := d.readSize4(reader)
 		if err != nil {
 			return 0, err
@@ -106,11 +68,6 @@ func (d *decoder) asUint(reader *bufio.Reader, k reflect.Kind) (uint64, error) {
 		return uint64(v), nil
 
 	case code == def.Uint64:
-		err = skipOne(reader)
-		if err != nil {
-			return 0, err
-		}
-
 		bs, err := d.readSize8(reader)
 		if err != nil {
 			return 0, err
@@ -118,11 +75,6 @@ func (d *decoder) asUint(reader *bufio.Reader, k reflect.Kind) (uint64, error) {
 		return binary.BigEndian.Uint64(bs[:]), nil
 
 	case code == def.Int64:
-		err = skipOne(reader)
-		if err != nil {
-			return 0, err
-		}
-
 		bs, err := d.readSize8(reader)
 		if err != nil {
 			return 0, err
@@ -130,7 +82,7 @@ func (d *decoder) asUint(reader *bufio.Reader, k reflect.Kind) (uint64, error) {
 		return binary.BigEndian.Uint64(bs[:]), nil
 
 	case code == def.Nil:
-		return 0, skipOne(reader)
+		return 0, nil
 	}
 
 	return 0, d.errorTemplate(code, k)

--- a/internal/encoding/bool.go
+++ b/internal/encoding/bool.go
@@ -1,8 +1,6 @@
 package encoding
 
 import (
-	"io"
-
 	"github.com/shamaton/msgpack/v2/def"
 )
 
@@ -10,7 +8,7 @@ import (
 //	return 0
 //}
 
-func (e *encoder) writeBool(v bool, writer io.Writer) error {
+func (e *encoder) writeBool(v bool, writer Writer) error {
 	if v {
 		return e.setByte1Int(def.True, writer)
 	} else {

--- a/internal/encoding/bool.go
+++ b/internal/encoding/bool.go
@@ -1,16 +1,19 @@
 package encoding
 
-import "github.com/shamaton/msgpack/v2/def"
+import (
+	"io"
+
+	"github.com/shamaton/msgpack/v2/def"
+)
 
 //func (e *encoder) calcBool() int {
 //	return 0
 //}
 
-func (e *encoder) writeBool(v bool, offset int) int {
+func (e *encoder) writeBool(v bool, writer io.Writer) error {
 	if v {
-		offset = e.setByte1Int(def.True, offset)
+		return e.setByte1Int(def.True, writer)
 	} else {
-		offset = e.setByte1Int(def.False, offset)
+		return e.setByte1Int(def.False, writer)
 	}
-	return offset
 }

--- a/internal/encoding/byte.go
+++ b/internal/encoding/byte.go
@@ -3,7 +3,6 @@ package encoding
 import (
 	"errors"
 	"fmt"
-	"io"
 	"math"
 	"reflect"
 
@@ -28,7 +27,7 @@ func (e *encoder) calcByteSlice(l int) (int, error) {
 	return 0, fmt.Errorf("not support this array length : %d", l)
 }
 
-func (e *encoder) writeByteSliceLength(l int, writer io.Writer) error {
+func (e *encoder) writeByteSliceLength(l int, writer Writer) error {
 	if l <= math.MaxUint8 {
 		err := e.setByte1Int(def.Bin8, writer)
 		if err != nil {

--- a/internal/encoding/byte.go
+++ b/internal/encoding/byte.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"math"
 	"reflect"
+	"strconv"
 
 	"github.com/shamaton/msgpack/v2/def"
 )
@@ -55,5 +56,5 @@ func (e *encoder) writeByteSliceLength(l int, writer Writer) error {
 		return e.setByte4Int(l, writer)
 	}
 
-	return errors.New("todo: unhandled byte slice length")
+	return errors.New("slice too large: " + strconv.FormatInt(int64(l), 10) + " elements")
 }

--- a/internal/encoding/complex.go
+++ b/internal/encoding/complex.go
@@ -1,6 +1,7 @@
 package encoding
 
 import (
+	"io"
 	"math"
 
 	"github.com/shamaton/msgpack/v2/def"
@@ -14,18 +15,40 @@ func (e *encoder) calcComplex128() int {
 	return def.Byte1 + def.Byte16
 }
 
-func (e *encoder) writeComplex64(v complex64, offset int) int {
-	offset = e.setByte1Int(def.Fixext8, offset)
-	offset = e.setByte1Int(int(def.ComplexTypeCode()), offset)
-	offset = e.setByte4Uint64(uint64(math.Float32bits(real(v))), offset)
-	offset = e.setByte4Uint64(uint64(math.Float32bits(imag(v))), offset)
-	return offset
+func (e *encoder) writeComplex64(v complex64, writer io.Writer) error {
+	err := e.setByte1Int(def.Fixext8, writer)
+	if err != nil {
+		return err
+	}
+
+	err = e.setByte1Int(int(def.ComplexTypeCode()), writer)
+	if err != nil {
+		return err
+	}
+
+	err = e.setByte4Uint64(uint64(math.Float32bits(real(v))), writer)
+	if err != nil {
+		return err
+	}
+
+	return e.setByte4Uint64(uint64(math.Float32bits(imag(v))), writer)
 }
 
-func (e *encoder) writeComplex128(v complex128, offset int) int {
-	offset = e.setByte1Int(def.Fixext16, offset)
-	offset = e.setByte1Int(int(def.ComplexTypeCode()), offset)
-	offset = e.setByte8Uint64(math.Float64bits(real(v)), offset)
-	offset = e.setByte8Uint64(math.Float64bits(imag(v)), offset)
-	return offset
+func (e *encoder) writeComplex128(v complex128, writer io.Writer) error {
+	err := e.setByte1Int(def.Fixext16, writer)
+	if err != nil {
+		return err
+	}
+
+	err = e.setByte1Int(int(def.ComplexTypeCode()), writer)
+	if err != nil {
+		return err
+	}
+
+	err = e.setByte8Uint64(math.Float64bits(real(v)), writer)
+	if err != nil {
+		return err
+	}
+
+	return e.setByte8Uint64(math.Float64bits(imag(v)), writer)
 }

--- a/internal/encoding/complex.go
+++ b/internal/encoding/complex.go
@@ -1,7 +1,6 @@
 package encoding
 
 import (
-	"io"
 	"math"
 
 	"github.com/shamaton/msgpack/v2/def"
@@ -15,7 +14,7 @@ func (e *encoder) calcComplex128() int {
 	return def.Byte1 + def.Byte16
 }
 
-func (e *encoder) writeComplex64(v complex64, writer io.Writer) error {
+func (e *encoder) writeComplex64(v complex64, writer Writer) error {
 	err := e.setByte1Int(def.Fixext8, writer)
 	if err != nil {
 		return err
@@ -34,7 +33,7 @@ func (e *encoder) writeComplex64(v complex64, writer io.Writer) error {
 	return e.setByte4Uint64(uint64(math.Float32bits(imag(v))), writer)
 }
 
-func (e *encoder) writeComplex128(v complex128, writer io.Writer) error {
+func (e *encoder) writeComplex128(v complex128, writer Writer) error {
 	err := e.setByte1Int(def.Fixext16, writer)
 	if err != nil {
 		return err

--- a/internal/encoding/encoding.go
+++ b/internal/encoding/encoding.go
@@ -36,7 +36,14 @@ func Encode(v interface{}, output io.Writer, asArray bool) (err error) {
 	bufWriter, ok := output.(Writer)
 	if !ok {
 		// otherwise, wrap the output in a bufio writer
-		bufWriter = bufio.NewWriter(output)
+		bW := bufio.NewWriter(output)
+		defer func() {
+			err2 := bW.Flush()
+			if err == nil && err2 != nil {
+				err = err2
+			}
+		}()
+		bufWriter = bW
 	}
 
 	return e.create(rv, bufWriter)

--- a/internal/encoding/encoding.go
+++ b/internal/encoding/encoding.go
@@ -402,15 +402,29 @@ func (e *encoder) create(rv reflect.Value, writer io.Writer) error {
 
 		// key-value
 		p := rv.Pointer()
-		for i := range e.mk[p] {
-			err = e.create(e.mk[p][i], writer)
-			if err != nil {
-				return err
-			}
+		if _, ok := e.mk[p]; ok {
+			for i := range e.mk[p] {
+				err = e.create(e.mk[p][i], writer)
+				if err != nil {
+					return err
+				}
 
-			err = e.create(e.mv[p][i], writer)
-			if err != nil {
-				return err
+				err = e.create(e.mv[p][i], writer)
+				if err != nil {
+					return err
+				}
+			}
+		} else {
+			for _, k := range rv.MapKeys() {
+				err = e.create(k, writer)
+				if err != nil {
+					return err
+				}
+
+				err = e.create(rv.MapIndex(k), writer)
+				if err != nil {
+					return err
+				}
 			}
 		}
 

--- a/internal/encoding/encoding.go
+++ b/internal/encoding/encoding.go
@@ -56,7 +56,7 @@ func EncodeBytes(v interface{}, asArray bool) (b []byte, err error) {
 		return nil, err
 	}
 	if size != writer.Len() {
-		return nil, fmt.Errorf("failed serialization size=%d, lastIdx=%d contents=%x", size, writer.Len(), writer.Bytes())
+		return nil, fmt.Errorf("failed serialization size=%d, lastIdx=%d", size, writer.Len())
 	}
 	return writer.Bytes(), err
 }

--- a/internal/encoding/encoding.go
+++ b/internal/encoding/encoding.go
@@ -321,11 +321,16 @@ func (e *encoder) create(rv reflect.Value, writer Writer) error {
 			return e.writeNil(writer)
 		}
 		l := rv.Len()
+
 		// bin format
 		if e.isByteSlice(rv) {
 			err := e.writeByteSliceLength(l, writer)
 			if err != nil {
 				return err
+			}
+
+			if l == 0 {
+				return nil
 			}
 
 			return e.setBytes(rv.Bytes(), writer)
@@ -335,6 +340,10 @@ func (e *encoder) create(rv reflect.Value, writer Writer) error {
 		err := e.writeSliceLength(l, writer)
 		if err != nil {
 			return err
+		}
+
+		if l == 0 {
+			return nil
 		}
 
 		if found, err := e.writeFixedSlice(rv, writer); found {
@@ -369,6 +378,10 @@ func (e *encoder) create(rv reflect.Value, writer Writer) error {
 				return err
 			}
 
+			if l == 0 {
+				return nil
+			}
+
 			// objects
 			for i := 0; i < l; i++ {
 				err = e.setByte1Uint64(rv.Index(i).Uint(), writer)
@@ -384,6 +397,10 @@ func (e *encoder) create(rv reflect.Value, writer Writer) error {
 		err := e.writeSliceLength(l, writer)
 		if err != nil {
 			return err
+		}
+
+		if l == 0 {
+			return nil
 		}
 
 		// func
@@ -414,6 +431,10 @@ func (e *encoder) create(rv reflect.Value, writer Writer) error {
 		err := e.writeMapLength(l, writer)
 		if err != nil {
 			return err
+		}
+
+		if l == 0 {
+			return nil
 		}
 
 		if found, err := e.writeFixedMap(rv, writer); found {

--- a/internal/encoding/encoding.go
+++ b/internal/encoding/encoding.go
@@ -61,18 +61,6 @@ func EncodeBytes(v interface{}, asArray bool) (b []byte, err error) {
 	return writer.Bytes(), err
 }
 
-//func stackTrace() string {
-//	msg := ""
-//	for depth := 0; ; depth++ {
-//		_, file, line, ok := runtime.Caller(depth)
-//		if !ok {
-//			break
-//		}
-//		msg += fmt.Sprintln(depth, ": ", file, ":", line)
-//	}
-//	return msg
-//}
-
 func (e *encoder) calcSize(rv reflect.Value) (int, error) {
 	ret := def.Byte1
 

--- a/internal/encoding/float.go
+++ b/internal/encoding/float.go
@@ -1,6 +1,7 @@
 package encoding
 
 import (
+	"io"
 	"math"
 
 	"github.com/shamaton/msgpack/v2/def"
@@ -14,14 +15,20 @@ func (e *encoder) calcFloat64(v float64) int {
 	return def.Byte8
 }
 
-func (e *encoder) writeFloat32(v float64, offset int) int {
-	offset = e.setByte1Int(def.Float32, offset)
-	offset = e.setByte4Uint64(uint64(math.Float32bits(float32(v))), offset)
-	return offset
+func (e *encoder) writeFloat32(v float64, writer io.Writer) error {
+	err := e.setByte1Int(def.Float32, writer)
+	if err != nil {
+		return err
+	}
+
+	return e.setByte4Uint64(uint64(math.Float32bits(float32(v))), writer)
 }
 
-func (e *encoder) writeFloat64(v float64, offset int) int {
-	offset = e.setByte1Int(def.Float64, offset)
-	offset = e.setByte8Uint64(math.Float64bits(v), offset)
-	return offset
+func (e *encoder) writeFloat64(v float64, writer io.Writer) error {
+	err := e.setByte1Int(def.Float64, writer)
+	if err != nil {
+		return err
+	}
+
+	return e.setByte8Uint64(math.Float64bits(v), writer)
 }

--- a/internal/encoding/float.go
+++ b/internal/encoding/float.go
@@ -1,7 +1,6 @@
 package encoding
 
 import (
-	"io"
 	"math"
 
 	"github.com/shamaton/msgpack/v2/def"
@@ -15,7 +14,7 @@ func (e *encoder) calcFloat64(v float64) int {
 	return def.Byte8
 }
 
-func (e *encoder) writeFloat32(v float64, writer io.Writer) error {
+func (e *encoder) writeFloat32(v float64, writer Writer) error {
 	err := e.setByte1Int(def.Float32, writer)
 	if err != nil {
 		return err
@@ -24,7 +23,7 @@ func (e *encoder) writeFloat32(v float64, writer io.Writer) error {
 	return e.setByte4Uint64(uint64(math.Float32bits(float32(v))), writer)
 }
 
-func (e *encoder) writeFloat64(v float64, writer io.Writer) error {
+func (e *encoder) writeFloat64(v float64, writer Writer) error {
 	err := e.setByte1Int(def.Float64, writer)
 	if err != nil {
 		return err

--- a/internal/encoding/int.go
+++ b/internal/encoding/int.go
@@ -1,7 +1,6 @@
 package encoding
 
 import (
-	"io"
 	"math"
 
 	"github.com/shamaton/msgpack/v2/def"
@@ -27,7 +26,7 @@ func (e *encoder) calcInt(v int64) int {
 	return def.Byte8
 }
 
-func (e *encoder) writeInt(v int64, writer io.Writer) error {
+func (e *encoder) writeInt(v int64, writer Writer) error {
 	if v >= 0 {
 		return e.writeUint(uint64(v), writer)
 	}

--- a/internal/encoding/map.go
+++ b/internal/encoding/map.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"math"
 	"reflect"
+	"strconv"
 
 	"github.com/shamaton/msgpack/v2/def"
 )
@@ -277,7 +278,7 @@ func (e *encoder) writeMapLength(l int, writer Writer) error {
 		return e.setByte4Int(l, writer)
 	}
 
-	return errors.New("todo: unhandled map length")
+	return errors.New("map too large: " + strconv.FormatInt(int64(l), 10) + " elements")
 }
 
 func (e *encoder) writeFixedMap(rv reflect.Value, writer Writer) (bool, error) {

--- a/internal/encoding/map.go
+++ b/internal/encoding/map.go
@@ -1,6 +1,8 @@
 package encoding
 
 import (
+	"errors"
+	"io"
 	"math"
 	"reflect"
 
@@ -256,265 +258,539 @@ func (e *encoder) calcFixedMap(rv reflect.Value) (int, bool) {
 	return size, false
 }
 
-func (e *encoder) writeMapLength(l int, offset int) int {
-
+func (e *encoder) writeMapLength(l int, writer io.Writer) error {
 	// format
 	if l <= 0x0f {
-		offset = e.setByte1Int(def.FixMap+l, offset)
+		return e.setByte1Int(def.FixMap+l, writer)
 	} else if l <= math.MaxUint16 {
-		offset = e.setByte1Int(def.Map16, offset)
-		offset = e.setByte2Int(l, offset)
+		err := e.setByte1Int(def.Map16, writer)
+		if err != nil {
+			return err
+		}
+
+		return e.setByte2Int(l, writer)
 	} else if uint(l) <= math.MaxUint32 {
-		offset = e.setByte1Int(def.Map32, offset)
-		offset = e.setByte4Int(l, offset)
+		err := e.setByte1Int(def.Map32, writer)
+		if err != nil {
+			return err
+		}
+
+		return e.setByte4Int(l, writer)
 	}
-	return offset
+
+	return errors.New("todo: unhandled map length")
 }
 
-func (e *encoder) writeFixedMap(rv reflect.Value, offset int) (int, bool) {
+func (e *encoder) writeFixedMap(rv reflect.Value, writer io.Writer) (bool, error) {
 	switch m := rv.Interface().(type) {
 	case map[string]int:
 		for k, v := range m {
-			offset = e.writeString(k, offset)
-			offset = e.writeInt(int64(v), offset)
+			err := e.writeString(k, writer)
+			if err != nil {
+				return true, err
+			}
+
+			err = e.writeInt(int64(v), writer)
+			if err != nil {
+				return true, err
+			}
 		}
-		return offset, true
+		return true, nil
 
 	case map[string]uint:
 		for k, v := range m {
-			offset = e.writeString(k, offset)
-			offset = e.writeUint(uint64(v), offset)
+			err := e.writeString(k, writer)
+			if err != nil {
+				return true, err
+			}
+
+			err = e.writeUint(uint64(v), writer)
+			if err != nil {
+				return true, err
+			}
 		}
-		return offset, true
+		return true, nil
 
 	case map[string]float32:
 		for k, v := range m {
-			offset = e.writeString(k, offset)
-			offset = e.writeFloat32(float64(v), offset)
+			err := e.writeString(k, writer)
+			if err != nil {
+				return true, err
+			}
+
+			err = e.writeFloat32(float64(v), writer)
+			if err != nil {
+				return true, err
+			}
 		}
-		return offset, true
+		return true, nil
 
 	case map[string]float64:
 		for k, v := range m {
-			offset = e.writeString(k, offset)
-			offset = e.writeFloat64(v, offset)
+			err := e.writeString(k, writer)
+			if err != nil {
+				return true, err
+			}
+
+			err = e.writeFloat64(v, writer)
+			if err != nil {
+				return true, err
+			}
 		}
-		return offset, true
+		return true, nil
 
 	case map[string]bool:
 		for k, v := range m {
-			offset = e.writeString(k, offset)
-			offset = e.writeBool(v, offset)
+			err := e.writeString(k, writer)
+			if err != nil {
+				return true, err
+			}
+
+			err = e.writeBool(v, writer)
+			if err != nil {
+				return true, err
+			}
 		}
-		return offset, true
+		return true, nil
 
 	case map[string]string:
 		for k, v := range m {
-			offset = e.writeString(k, offset)
-			offset = e.writeString(v, offset)
+			err := e.writeString(k, writer)
+			if err != nil {
+				return true, err
+			}
+
+			err = e.writeString(v, writer)
+			if err != nil {
+				return true, err
+			}
 		}
-		return offset, true
+		return true, nil
 
 	case map[string]int8:
 		for k, v := range m {
-			offset = e.writeString(k, offset)
-			offset = e.writeInt(int64(v), offset)
+			err := e.writeString(k, writer)
+			if err != nil {
+				return true, err
+			}
+
+			err = e.writeInt(int64(v), writer)
+			if err != nil {
+				return true, err
+			}
 		}
-		return offset, true
+		return true, nil
 	case map[string]int16:
 		for k, v := range m {
-			offset = e.writeString(k, offset)
-			offset = e.writeInt(int64(v), offset)
+			err := e.writeString(k, writer)
+			if err != nil {
+				return true, err
+			}
+
+			err = e.writeInt(int64(v), writer)
+			if err != nil {
+				return true, err
+			}
 		}
-		return offset, true
+		return true, nil
 	case map[string]int32:
 		for k, v := range m {
-			offset = e.writeString(k, offset)
-			offset = e.writeInt(int64(v), offset)
+			err := e.writeString(k, writer)
+			if err != nil {
+				return true, err
+			}
+
+			err = e.writeInt(int64(v), writer)
+			if err != nil {
+				return true, err
+			}
 		}
-		return offset, true
+		return true, nil
 	case map[string]int64:
 		for k, v := range m {
-			offset = e.writeString(k, offset)
-			offset = e.writeInt(int64(v), offset)
+			err := e.writeString(k, writer)
+			if err != nil {
+				return true, err
+			}
+
+			err = e.writeInt(int64(v), writer)
+			if err != nil {
+				return true, err
+			}
 		}
-		return offset, true
+		return true, nil
 
 	case map[string]uint8:
 		for k, v := range m {
-			offset = e.writeString(k, offset)
-			offset = e.writeUint(uint64(v), offset)
+			err := e.writeString(k, writer)
+			if err != nil {
+				return true, err
+			}
+
+			err = e.writeUint(uint64(v), writer)
+			if err != nil {
+				return true, err
+			}
 		}
-		return offset, true
+		return true, nil
 	case map[string]uint16:
 		for k, v := range m {
-			offset = e.writeString(k, offset)
-			offset = e.writeUint(uint64(v), offset)
+			err := e.writeString(k, writer)
+			if err != nil {
+				return true, err
+			}
+
+			err = e.writeUint(uint64(v), writer)
+			if err != nil {
+				return true, err
+			}
 		}
-		return offset, true
+		return true, nil
 	case map[string]uint32:
 		for k, v := range m {
-			offset = e.writeString(k, offset)
-			offset = e.writeUint(uint64(v), offset)
+			err := e.writeString(k, writer)
+			if err != nil {
+				return true, err
+			}
+
+			err = e.writeUint(uint64(v), writer)
+			if err != nil {
+				return true, err
+			}
 		}
-		return offset, true
+		return true, nil
 	case map[string]uint64:
 		for k, v := range m {
-			offset = e.writeString(k, offset)
-			offset = e.writeUint(uint64(v), offset)
+			err := e.writeString(k, writer)
+			if err != nil {
+				return true, err
+			}
+
+			err = e.writeUint(uint64(v), writer)
+			if err != nil {
+				return true, err
+			}
 		}
-		return offset, true
+		return true, nil
 
 	case map[int]string:
 		for k, v := range m {
-			offset = e.writeInt(int64(k), offset)
-			offset = e.writeString(v, offset)
+			err := e.writeInt(int64(k), writer)
+			if err != nil {
+				return true, err
+			}
+
+			err = e.writeString(v, writer)
+			if err != nil {
+				return true, err
+			}
 		}
-		return offset, true
+		return true, nil
 	case map[int]bool:
 		for k, v := range m {
-			offset = e.writeInt(int64(k), offset)
-			offset = e.writeBool(v, offset)
+			err := e.writeInt(int64(k), writer)
+			if err != nil {
+				return true, err
+			}
+
+			err = e.writeBool(v, writer)
+			if err != nil {
+				return true, err
+			}
 		}
-		return offset, true
+		return true, nil
 
 	case map[uint]string:
 		for k, v := range m {
-			offset = e.writeUint(uint64(k), offset)
-			offset = e.writeString(v, offset)
+			err := e.writeUint(uint64(k), writer)
+			if err != nil {
+				return true, err
+			}
+
+			err = e.writeString(v, writer)
+			if err != nil {
+				return true, err
+			}
 		}
-		return offset, true
+		return true, nil
 	case map[uint]bool:
 		for k, v := range m {
-			offset = e.writeUint(uint64(k), offset)
-			offset = e.writeBool(v, offset)
+			err := e.writeUint(uint64(k), writer)
+			if err != nil {
+				return true, err
+			}
+
+			err = e.writeBool(v, writer)
+			if err != nil {
+				return true, err
+			}
 		}
-		return offset, true
+		return true, nil
 
 	case map[float32]string:
 		for k, v := range m {
-			offset = e.writeFloat32(float64(k), offset)
-			offset = e.writeString(v, offset)
+			err := e.writeFloat32(float64(k), writer)
+			if err != nil {
+				return true, err
+			}
+
+			err = e.writeString(v, writer)
+			if err != nil {
+				return true, err
+			}
 		}
-		return offset, true
+		return true, nil
 	case map[float32]bool:
 		for k, v := range m {
-			offset = e.writeFloat32(float64(k), offset)
-			offset = e.writeBool(v, offset)
+			err := e.writeFloat32(float64(k), writer)
+			if err != nil {
+				return true, err
+			}
+
+			err = e.writeBool(v, writer)
+			if err != nil {
+				return true, err
+			}
 		}
-		return offset, true
+		return true, nil
 
 	case map[float64]string:
 		for k, v := range m {
-			offset = e.writeFloat64(k, offset)
-			offset = e.writeString(v, offset)
+			err := e.writeFloat64(k, writer)
+			if err != nil {
+				return true, err
+			}
+
+			err = e.writeString(v, writer)
+			if err != nil {
+				return true, err
+			}
 		}
-		return offset, true
+		return true, nil
 	case map[float64]bool:
 		for k, v := range m {
-			offset = e.writeFloat64(k, offset)
-			offset = e.writeBool(v, offset)
+			err := e.writeFloat64(k, writer)
+			if err != nil {
+				return true, err
+			}
+
+			err = e.writeBool(v, writer)
+			if err != nil {
+				return true, err
+			}
 		}
-		return offset, true
+		return true, nil
 
 	case map[int8]string:
 		for k, v := range m {
-			offset = e.writeInt(int64(k), offset)
-			offset = e.writeString(v, offset)
+			err := e.writeInt(int64(k), writer)
+			if err != nil {
+				return true, err
+			}
+
+			err = e.writeString(v, writer)
+			if err != nil {
+				return true, err
+			}
 		}
-		return offset, true
+		return true, nil
 	case map[int8]bool:
 		for k, v := range m {
-			offset = e.writeInt(int64(k), offset)
-			offset = e.writeBool(v, offset)
+			err := e.writeInt(int64(k), writer)
+			if err != nil {
+				return true, err
+			}
+
+			err = e.writeBool(v, writer)
+			if err != nil {
+				return true, err
+			}
 		}
-		return offset, true
+		return true, nil
 	case map[int16]string:
 		for k, v := range m {
-			offset = e.writeInt(int64(k), offset)
-			offset = e.writeString(v, offset)
+			err := e.writeInt(int64(k), writer)
+			if err != nil {
+				return true, err
+			}
+
+			err = e.writeString(v, writer)
+			if err != nil {
+				return true, err
+			}
 		}
-		return offset, true
+		return true, nil
 	case map[int16]bool:
 		for k, v := range m {
-			offset = e.writeInt(int64(k), offset)
-			offset = e.writeBool(v, offset)
+			err := e.writeInt(int64(k), writer)
+			if err != nil {
+				return true, err
+			}
+
+			err = e.writeBool(v, writer)
+			if err != nil {
+				return true, err
+			}
 		}
-		return offset, true
+		return true, nil
 	case map[int32]string:
 		for k, v := range m {
-			offset = e.writeInt(int64(k), offset)
-			offset = e.writeString(v, offset)
+			err := e.writeInt(int64(k), writer)
+			if err != nil {
+				return true, err
+			}
+
+			err = e.writeString(v, writer)
+			if err != nil {
+				return true, err
+			}
 		}
-		return offset, true
+		return true, nil
 	case map[int32]bool:
 		for k, v := range m {
-			offset = e.writeInt(int64(k), offset)
-			offset = e.writeBool(v, offset)
+			err := e.writeInt(int64(k), writer)
+			if err != nil {
+				return true, err
+			}
+
+			err = e.writeBool(v, writer)
+			if err != nil {
+				return true, err
+			}
 		}
-		return offset, true
+		return true, nil
 	case map[int64]string:
 		for k, v := range m {
-			offset = e.writeInt(k, offset)
-			offset = e.writeString(v, offset)
+			err := e.writeInt(k, writer)
+			if err != nil {
+				return true, err
+			}
+
+			err = e.writeString(v, writer)
+			if err != nil {
+				return true, err
+			}
 		}
-		return offset, true
+		return true, nil
 	case map[int64]bool:
 		for k, v := range m {
-			offset = e.writeInt(k, offset)
-			offset = e.writeBool(v, offset)
+			err := e.writeInt(k, writer)
+			if err != nil {
+				return true, err
+			}
+
+			err = e.writeBool(v, writer)
+			if err != nil {
+				return true, err
+			}
 		}
-		return offset, true
+		return true, nil
 
 	case map[uint8]string:
 		for k, v := range m {
-			offset = e.writeUint(uint64(k), offset)
-			offset = e.writeString(v, offset)
+			err := e.writeUint(uint64(k), writer)
+			if err != nil {
+				return true, err
+			}
+
+			err = e.writeString(v, writer)
+			if err != nil {
+				return true, err
+			}
 		}
-		return offset, true
+		return true, nil
 	case map[uint8]bool:
 		for k, v := range m {
-			offset = e.writeUint(uint64(k), offset)
-			offset = e.writeBool(v, offset)
+			err := e.writeUint(uint64(k), writer)
+			if err != nil {
+				return true, err
+			}
+
+			err = e.writeBool(v, writer)
+			if err != nil {
+				return true, err
+			}
 		}
-		return offset, true
+		return true, nil
 	case map[uint16]string:
 		for k, v := range m {
-			offset = e.writeUint(uint64(k), offset)
-			offset = e.writeString(v, offset)
+			err := e.writeUint(uint64(k), writer)
+			if err != nil {
+				return true, err
+			}
+
+			err = e.writeString(v, writer)
+			if err != nil {
+				return true, err
+			}
 		}
-		return offset, true
+		return true, nil
 	case map[uint16]bool:
 		for k, v := range m {
-			offset = e.writeUint(uint64(k), offset)
-			offset = e.writeBool(v, offset)
+			err := e.writeUint(uint64(k), writer)
+			if err != nil {
+				return true, err
+			}
+
+			err = e.writeBool(v, writer)
+			if err != nil {
+				return true, err
+			}
 		}
-		return offset, true
+		return true, nil
 	case map[uint32]string:
 		for k, v := range m {
-			offset = e.writeUint(uint64(k), offset)
-			offset = e.writeString(v, offset)
+			err := e.writeUint(uint64(k), writer)
+			if err != nil {
+				return true, err
+			}
+
+			err = e.writeString(v, writer)
+			if err != nil {
+				return true, err
+			}
 		}
-		return offset, true
+		return true, nil
 	case map[uint32]bool:
 		for k, v := range m {
-			offset = e.writeUint(uint64(k), offset)
-			offset = e.writeBool(v, offset)
+			err := e.writeUint(uint64(k), writer)
+			if err != nil {
+				return true, err
+			}
+
+			err = e.writeBool(v, writer)
+			if err != nil {
+				return true, err
+			}
 		}
-		return offset, true
+		return true, nil
 	case map[uint64]string:
 		for k, v := range m {
-			offset = e.writeUint(k, offset)
-			offset = e.writeString(v, offset)
+			err := e.writeUint(k, writer)
+			if err != nil {
+				return true, err
+			}
+
+			err = e.writeString(v, writer)
+			if err != nil {
+				return true, err
+			}
 		}
-		return offset, true
+		return true, nil
 	case map[uint64]bool:
 		for k, v := range m {
-			offset = e.writeUint(k, offset)
-			offset = e.writeBool(v, offset)
-		}
-		return offset, true
+			err := e.writeUint(k, writer)
+			if err != nil {
+				return true, err
+			}
 
+			err = e.writeBool(v, writer)
+			if err != nil {
+				return true, err
+			}
+		}
+		return true, nil
 	}
-	return offset, false
+
+	return false, nil
 }

--- a/internal/encoding/map.go
+++ b/internal/encoding/map.go
@@ -2,7 +2,6 @@ package encoding
 
 import (
 	"errors"
-	"io"
 	"math"
 	"reflect"
 
@@ -258,7 +257,7 @@ func (e *encoder) calcFixedMap(rv reflect.Value) (int, bool) {
 	return size, false
 }
 
-func (e *encoder) writeMapLength(l int, writer io.Writer) error {
+func (e *encoder) writeMapLength(l int, writer Writer) error {
 	// format
 	if l <= 0x0f {
 		return e.setByte1Int(def.FixMap+l, writer)
@@ -281,7 +280,7 @@ func (e *encoder) writeMapLength(l int, writer io.Writer) error {
 	return errors.New("todo: unhandled map length")
 }
 
-func (e *encoder) writeFixedMap(rv reflect.Value, writer io.Writer) (bool, error) {
+func (e *encoder) writeFixedMap(rv reflect.Value, writer Writer) (bool, error) {
 	switch m := rv.Interface().(type) {
 	case map[string]int:
 		for k, v := range m {

--- a/internal/encoding/nil.go
+++ b/internal/encoding/nil.go
@@ -1,8 +1,11 @@
 package encoding
 
-import "github.com/shamaton/msgpack/v2/def"
+import (
+	"io"
 
-func (e *encoder) writeNil(offset int) int {
-	offset = e.setByte1Int(def.Nil, offset)
-	return offset
+	"github.com/shamaton/msgpack/v2/def"
+)
+
+func (e *encoder) writeNil(writer io.Writer) error {
+	return e.setByte1Int(def.Nil, writer)
 }

--- a/internal/encoding/nil.go
+++ b/internal/encoding/nil.go
@@ -1,11 +1,9 @@
 package encoding
 
 import (
-	"io"
-
 	"github.com/shamaton/msgpack/v2/def"
 )
 
-func (e *encoder) writeNil(writer io.Writer) error {
+func (e *encoder) writeNil(writer Writer) error {
 	return e.setByte1Int(def.Nil, writer)
 }

--- a/internal/encoding/set.go
+++ b/internal/encoding/set.go
@@ -1,89 +1,107 @@
 package encoding
 
-func (e *encoder) setByte1Int64(value int64, offset int) int {
-	e.d[offset] = byte(value)
-	return offset + 1
+import (
+	"io"
+)
+
+func (e *encoder) setByte1Int64(value int64, writer io.Writer) error {
+	_, err := writer.Write([]byte{byte(value)})
+	return err
 }
 
-func (e *encoder) setByte2Int64(value int64, offset int) int {
-	e.d[offset+0] = byte(value >> 8)
-	e.d[offset+1] = byte(value)
-	return offset + 2
+func (e *encoder) setByte2Int64(value int64, writer io.Writer) error {
+	_, err := writer.Write([]byte{
+		byte(value >> 8),
+		byte(value),
+	})
+	return err
 }
 
-func (e *encoder) setByte4Int64(value int64, offset int) int {
-	e.d[offset+0] = byte(value >> 24)
-	e.d[offset+1] = byte(value >> 16)
-	e.d[offset+2] = byte(value >> 8)
-	e.d[offset+3] = byte(value)
-	return offset + 4
+func (e *encoder) setByte4Int64(value int64, writer io.Writer) error {
+	_, err := writer.Write([]byte{
+		byte(value >> 24),
+		byte(value >> 16),
+		byte(value >> 8),
+		byte(value),
+	})
+	return err
 }
 
-func (e *encoder) setByte8Int64(value int64, offset int) int {
-	e.d[offset] = byte(value >> 56)
-	e.d[offset+1] = byte(value >> 48)
-	e.d[offset+2] = byte(value >> 40)
-	e.d[offset+3] = byte(value >> 32)
-	e.d[offset+4] = byte(value >> 24)
-	e.d[offset+5] = byte(value >> 16)
-	e.d[offset+6] = byte(value >> 8)
-	e.d[offset+7] = byte(value)
-	return offset + 8
+func (e *encoder) setByte8Int64(value int64, writer io.Writer) error {
+	_, err := writer.Write([]byte{
+		byte(value >> 56),
+		byte(value >> 48),
+		byte(value >> 40),
+		byte(value >> 32),
+		byte(value >> 24),
+		byte(value >> 16),
+		byte(value >> 8),
+		byte(value),
+	})
+	return err
 }
 
-func (e *encoder) setByte1Uint64(value uint64, offset int) int {
-	e.d[offset] = byte(value)
-	return offset + 1
+func (e *encoder) setByte1Uint64(value uint64, writer io.Writer) error {
+	_, err := writer.Write([]byte{byte(value)})
+	return err
 }
 
-func (e *encoder) setByte2Uint64(value uint64, offset int) int {
-	e.d[offset] = byte(value >> 8)
-	e.d[offset+1] = byte(value)
-	return offset + 2
+func (e *encoder) setByte2Uint64(value uint64, writer io.Writer) error {
+	_, err := writer.Write([]byte{
+		byte(value >> 8),
+		byte(value),
+	})
+	return err
 }
 
-func (e *encoder) setByte4Uint64(value uint64, offset int) int {
-	e.d[offset] = byte(value >> 24)
-	e.d[offset+1] = byte(value >> 16)
-	e.d[offset+2] = byte(value >> 8)
-	e.d[offset+3] = byte(value)
-	return offset + 4
+func (e *encoder) setByte4Uint64(value uint64, writer io.Writer) error {
+	_, err := writer.Write([]byte{
+		byte(value >> 24),
+		byte(value >> 16),
+		byte(value >> 8),
+		byte(value),
+	})
+	return err
 }
 
-func (e *encoder) setByte8Uint64(value uint64, offset int) int {
-	e.d[offset] = byte(value >> 56)
-	e.d[offset+1] = byte(value >> 48)
-	e.d[offset+2] = byte(value >> 40)
-	e.d[offset+3] = byte(value >> 32)
-	e.d[offset+4] = byte(value >> 24)
-	e.d[offset+5] = byte(value >> 16)
-	e.d[offset+6] = byte(value >> 8)
-	e.d[offset+7] = byte(value)
-	return offset + 8
+func (e *encoder) setByte8Uint64(value uint64, writer io.Writer) error {
+	_, err := writer.Write([]byte{
+		byte(value >> 56),
+		byte(value >> 48),
+		byte(value >> 40),
+		byte(value >> 32),
+		byte(value >> 24),
+		byte(value >> 16),
+		byte(value >> 8),
+		byte(value),
+	})
+	return err
 }
 
-func (e *encoder) setByte1Int(code, offset int) int {
-	e.d[offset] = byte(code)
-	return offset + 1
+func (e *encoder) setByte1Int(code int, writer io.Writer) error {
+	_, err := writer.Write([]byte{byte(code)})
+	return err
 }
 
-func (e *encoder) setByte2Int(value int, offset int) int {
-	e.d[offset] = byte(value >> 8)
-	e.d[offset+1] = byte(value)
-	return offset + 2
+func (e *encoder) setByte2Int(value int, writer io.Writer) error {
+	_, err := writer.Write([]byte{
+		byte(value >> 8),
+		byte(value),
+	})
+	return err
 }
 
-func (e *encoder) setByte4Int(value int, offset int) int {
-	e.d[offset] = byte(value >> 24)
-	e.d[offset+1] = byte(value >> 16)
-	e.d[offset+2] = byte(value >> 8)
-	e.d[offset+3] = byte(value)
-	return offset + 4
+func (e *encoder) setByte4Int(value int, writer io.Writer) error {
+	_, err := writer.Write([]byte{
+		byte(value >> 24),
+		byte(value >> 16),
+		byte(value >> 8),
+		byte(value),
+	})
+	return err
 }
 
-func (e *encoder) setBytes(bs []byte, offset int) int {
-	for i := range bs {
-		e.d[offset+i] = bs[i]
-	}
-	return offset + len(bs)
+func (e *encoder) setBytes(bs []byte, writer io.Writer) error {
+	_, err := writer.Write(bs)
+	return err
 }

--- a/internal/encoding/set.go
+++ b/internal/encoding/set.go
@@ -1,107 +1,154 @@
 package encoding
 
-import (
-	"io"
-)
-
-func (e *encoder) setByte1Int64(value int64, writer io.Writer) error {
-	_, err := writer.Write([]byte{byte(value)})
-	return err
+func (e *encoder) setByte1Int64(value int64, writer Writer) error {
+	return writer.WriteByte(byte(value))
 }
 
-func (e *encoder) setByte2Int64(value int64, writer io.Writer) error {
-	_, err := writer.Write([]byte{
-		byte(value >> 8),
-		byte(value),
-	})
-	return err
+func (e *encoder) setByte2Int64(value int64, writer Writer) error {
+	err := writer.WriteByte(byte(value >> 8))
+	if err != nil {
+		return err
+	}
+	return writer.WriteByte(byte(value))
 }
 
-func (e *encoder) setByte4Int64(value int64, writer io.Writer) error {
-	_, err := writer.Write([]byte{
-		byte(value >> 24),
-		byte(value >> 16),
-		byte(value >> 8),
-		byte(value),
-	})
-	return err
+func (e *encoder) setByte4Int64(value int64, writer Writer) error {
+	err := writer.WriteByte(byte(value >> 24))
+	if err != nil {
+		return err
+	}
+	err = writer.WriteByte(byte(value >> 16))
+	if err != nil {
+		return err
+	}
+	err = writer.WriteByte(byte(value >> 8))
+	if err != nil {
+		return err
+	}
+	return writer.WriteByte(byte(value))
 }
 
-func (e *encoder) setByte8Int64(value int64, writer io.Writer) error {
-	_, err := writer.Write([]byte{
-		byte(value >> 56),
-		byte(value >> 48),
-		byte(value >> 40),
-		byte(value >> 32),
-		byte(value >> 24),
-		byte(value >> 16),
-		byte(value >> 8),
-		byte(value),
-	})
-	return err
+func (e *encoder) setByte8Int64(value int64, writer Writer) error {
+	err := writer.WriteByte(byte(value >> 56))
+	if err != nil {
+		return err
+	}
+	err = writer.WriteByte(byte(value >> 48))
+	if err != nil {
+		return err
+	}
+	err = writer.WriteByte(byte(value >> 40))
+	if err != nil {
+		return err
+	}
+	err = writer.WriteByte(byte(value >> 32))
+	if err != nil {
+		return err
+	}
+	err = writer.WriteByte(byte(value >> 24))
+	if err != nil {
+		return err
+	}
+	err = writer.WriteByte(byte(value >> 16))
+	if err != nil {
+		return err
+	}
+	err = writer.WriteByte(byte(value >> 8))
+	if err != nil {
+		return err
+	}
+	return writer.WriteByte(byte(value))
 }
 
-func (e *encoder) setByte1Uint64(value uint64, writer io.Writer) error {
-	_, err := writer.Write([]byte{byte(value)})
-	return err
+func (e *encoder) setByte1Uint64(value uint64, writer Writer) error {
+	return writer.WriteByte(byte(value))
 }
 
-func (e *encoder) setByte2Uint64(value uint64, writer io.Writer) error {
-	_, err := writer.Write([]byte{
-		byte(value >> 8),
-		byte(value),
-	})
-	return err
+func (e *encoder) setByte2Uint64(value uint64, writer Writer) error {
+	err := writer.WriteByte(byte(value >> 8))
+	if err != nil {
+		return err
+	}
+	return writer.WriteByte(byte(value))
 }
 
-func (e *encoder) setByte4Uint64(value uint64, writer io.Writer) error {
-	_, err := writer.Write([]byte{
-		byte(value >> 24),
-		byte(value >> 16),
-		byte(value >> 8),
-		byte(value),
-	})
-	return err
+func (e *encoder) setByte4Uint64(value uint64, writer Writer) error {
+	err := writer.WriteByte(byte(value >> 24))
+	if err != nil {
+		return err
+	}
+	err = writer.WriteByte(byte(value >> 16))
+	if err != nil {
+		return err
+	}
+	err = writer.WriteByte(byte(value >> 8))
+	if err != nil {
+		return err
+	}
+	return writer.WriteByte(byte(value))
 }
 
-func (e *encoder) setByte8Uint64(value uint64, writer io.Writer) error {
-	_, err := writer.Write([]byte{
-		byte(value >> 56),
-		byte(value >> 48),
-		byte(value >> 40),
-		byte(value >> 32),
-		byte(value >> 24),
-		byte(value >> 16),
-		byte(value >> 8),
-		byte(value),
-	})
-	return err
+func (e *encoder) setByte8Uint64(value uint64, writer Writer) error {
+	err := writer.WriteByte(byte(value >> 56))
+	if err != nil {
+		return err
+	}
+	err = writer.WriteByte(byte(value >> 48))
+	if err != nil {
+		return err
+	}
+	err = writer.WriteByte(byte(value >> 40))
+	if err != nil {
+		return err
+	}
+	err = writer.WriteByte(byte(value >> 32))
+	if err != nil {
+		return err
+	}
+	err = writer.WriteByte(byte(value >> 24))
+	if err != nil {
+		return err
+	}
+	err = writer.WriteByte(byte(value >> 16))
+	if err != nil {
+		return err
+	}
+	err = writer.WriteByte(byte(value >> 8))
+	if err != nil {
+		return err
+	}
+	return writer.WriteByte(byte(value))
 }
 
-func (e *encoder) setByte1Int(code int, writer io.Writer) error {
-	_, err := writer.Write([]byte{byte(code)})
-	return err
+func (e *encoder) setByte1Int(code int, writer Writer) error {
+	return writer.WriteByte(byte(code))
 }
 
-func (e *encoder) setByte2Int(value int, writer io.Writer) error {
-	_, err := writer.Write([]byte{
-		byte(value >> 8),
-		byte(value),
-	})
-	return err
+func (e *encoder) setByte2Int(value int, writer Writer) error {
+	err := writer.WriteByte(byte(value >> 8))
+	if err != nil {
+		return err
+	}
+	return writer.WriteByte(byte(value))
 }
 
-func (e *encoder) setByte4Int(value int, writer io.Writer) error {
-	_, err := writer.Write([]byte{
-		byte(value >> 24),
-		byte(value >> 16),
-		byte(value >> 8),
-		byte(value),
-	})
-	return err
+func (e *encoder) setByte4Int(value int, writer Writer) error {
+	err := writer.WriteByte(byte(value >> 24))
+	if err != nil {
+		return err
+	}
+	err = writer.WriteByte(byte(value >> 16))
+	if err != nil {
+		return err
+	}
+	err = writer.WriteByte(byte(value >> 8))
+	if err != nil {
+		return err
+	}
+	return writer.WriteByte(byte(value))
 }
 
-func (e *encoder) setBytes(bs []byte, writer io.Writer) error {
+func (e *encoder) setBytes(bs []byte, writer Writer) error {
 	_, err := writer.Write(bs)
 	return err
 }

--- a/internal/encoding/slice.go
+++ b/internal/encoding/slice.go
@@ -2,7 +2,6 @@ package encoding
 
 import (
 	"errors"
-	"io"
 	"math"
 	"reflect"
 
@@ -99,7 +98,7 @@ func (e *encoder) calcFixedSlice(rv reflect.Value) (int, bool) {
 	return size, false
 }
 
-func (e *encoder) writeSliceLength(l int, writer io.Writer) (err error) {
+func (e *encoder) writeSliceLength(l int, writer Writer) (err error) {
 	// format size
 	if l <= 0x0f {
 		return e.setByte1Int(def.FixArray+l, writer)
@@ -122,7 +121,7 @@ func (e *encoder) writeSliceLength(l int, writer io.Writer) (err error) {
 	return errors.New("todo: unhandled slice length")
 }
 
-func (e *encoder) writeFixedSlice(rv reflect.Value, writer io.Writer) (bool, error) {
+func (e *encoder) writeFixedSlice(rv reflect.Value, writer Writer) (bool, error) {
 
 	switch sli := rv.Interface().(type) {
 	case []int:

--- a/internal/encoding/slice.go
+++ b/internal/encoding/slice.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"math"
 	"reflect"
+	"strconv"
 
 	"github.com/shamaton/msgpack/v2/def"
 )
@@ -118,7 +119,7 @@ func (e *encoder) writeSliceLength(l int, writer Writer) (err error) {
 		return e.setByte4Int(l, writer)
 	}
 
-	return errors.New("todo: unhandled slice length")
+	return errors.New("slice too large: " + strconv.FormatInt(int64(l), 10) + " elements")
 }
 
 func (e *encoder) writeFixedSlice(rv reflect.Value, writer Writer) (bool, error) {

--- a/internal/encoding/slice.go
+++ b/internal/encoding/slice.go
@@ -1,6 +1,8 @@
 package encoding
 
 import (
+	"errors"
+	"io"
 	"math"
 	"reflect"
 
@@ -97,107 +99,158 @@ func (e *encoder) calcFixedSlice(rv reflect.Value) (int, bool) {
 	return size, false
 }
 
-func (e *encoder) writeSliceLength(l int, offset int) int {
+func (e *encoder) writeSliceLength(l int, writer io.Writer) (err error) {
 	// format size
 	if l <= 0x0f {
-		offset = e.setByte1Int(def.FixArray+l, offset)
+		return e.setByte1Int(def.FixArray+l, writer)
 	} else if l <= math.MaxUint16 {
-		offset = e.setByte1Int(def.Array16, offset)
-		offset = e.setByte2Int(l, offset)
+		err = e.setByte1Int(def.Array16, writer)
+		if err != nil {
+			return err
+		}
+
+		return e.setByte2Int(l, writer)
 	} else if uint(l) <= math.MaxUint32 {
-		offset = e.setByte1Int(def.Array32, offset)
-		offset = e.setByte4Int(l, offset)
+		err = e.setByte1Int(def.Array32, writer)
+		if err != nil {
+			return err
+		}
+
+		return e.setByte4Int(l, writer)
 	}
-	return offset
+
+	return errors.New("todo: unhandled slice length")
 }
 
-func (e *encoder) writeFixedSlice(rv reflect.Value, offset int) (int, bool) {
+func (e *encoder) writeFixedSlice(rv reflect.Value, writer io.Writer) (bool, error) {
 
 	switch sli := rv.Interface().(type) {
 	case []int:
 		for _, v := range sli {
-			offset = e.writeInt(int64(v), offset)
+			err := e.writeInt(int64(v), writer)
+			if err != nil {
+				return true, err
+			}
 		}
-		return offset, true
+		return true, nil
 
 	case []uint:
 		for _, v := range sli {
-			offset = e.writeUint(uint64(v), offset)
+			err := e.writeUint(uint64(v), writer)
+			if err != nil {
+				return true, err
+			}
 		}
-		return offset, true
+		return true, nil
 
 	case []string:
 		for _, v := range sli {
-			offset = e.writeString(v, offset)
+			err := e.writeString(v, writer)
+			if err != nil {
+				return true, err
+			}
 		}
-		return offset, true
+		return true, nil
 
 	case []float32:
 		for _, v := range sli {
-			offset = e.writeFloat32(float64(v), offset)
+			err := e.writeFloat32(float64(v), writer)
+			if err != nil {
+				return true, err
+			}
 		}
-		return offset, true
+		return true, nil
 
 	case []float64:
 		for _, v := range sli {
-			offset = e.writeFloat64(float64(v), offset)
+			err := e.writeFloat64(float64(v), writer)
+			if err != nil {
+				return true, err
+			}
 		}
-		return offset, true
+		return true, nil
 
 	case []bool:
 		for _, v := range sli {
-			offset = e.writeBool(v, offset)
+			err := e.writeBool(v, writer)
+			if err != nil {
+				return true, err
+			}
 		}
-		return offset, true
+		return true, nil
 
 	case []int8:
 		for _, v := range sli {
-			offset = e.writeInt(int64(v), offset)
+			err := e.writeInt(int64(v), writer)
+			if err != nil {
+				return true, err
+			}
 		}
-		return offset, true
+		return true, nil
 
 	case []int16:
 		for _, v := range sli {
-			offset = e.writeInt(int64(v), offset)
+			err := e.writeInt(int64(v), writer)
+			if err != nil {
+				return true, err
+			}
 		}
-		return offset, true
+		return true, nil
 
 	case []int32:
 		for _, v := range sli {
-			offset = e.writeInt(int64(v), offset)
+			err := e.writeInt(int64(v), writer)
+			if err != nil {
+				return true, err
+			}
 		}
-		return offset, true
+		return true, nil
 
 	case []int64:
 		for _, v := range sli {
-			offset = e.writeInt(v, offset)
+			err := e.writeInt(v, writer)
+			if err != nil {
+				return true, err
+			}
 		}
-		return offset, true
+		return true, nil
 
 	case []uint8:
 		for _, v := range sli {
-			offset = e.writeUint(uint64(v), offset)
+			err := e.writeUint(uint64(v), writer)
+			if err != nil {
+				return true, err
+			}
 		}
-		return offset, true
+		return true, nil
 
 	case []uint16:
 		for _, v := range sli {
-			offset = e.writeUint(uint64(v), offset)
+			err := e.writeUint(uint64(v), writer)
+			if err != nil {
+				return true, err
+			}
 		}
-		return offset, true
+		return true, nil
 
 	case []uint32:
 		for _, v := range sli {
-			offset = e.writeUint(uint64(v), offset)
+			err := e.writeUint(uint64(v), writer)
+			if err != nil {
+				return true, err
+			}
 		}
-		return offset, true
+		return true, nil
 
 	case []uint64:
 		for _, v := range sli {
-			offset = e.writeUint(v, offset)
+			err := e.writeUint(v, writer)
+			if err != nil {
+				return true, err
+			}
 		}
-		return offset, true
+		return true, nil
 	}
 
-	return offset, false
+	return false, nil
 }

--- a/internal/encoding/string.go
+++ b/internal/encoding/string.go
@@ -19,7 +19,7 @@ func (e *encoder) calcString(v string) int {
 	return def.Byte4 + l
 }
 
-func (e *encoder) writeString(str string, writer io.Writer) (err error) {
+func (e *encoder) writeString(str string, writer Writer) (err error) {
 	l := len(str)
 	if l < 32 {
 		err = e.setByte1Int(def.FixStr+l, writer)

--- a/internal/encoding/string.go
+++ b/internal/encoding/string.go
@@ -3,15 +3,12 @@ package encoding
 import (
 	"io"
 	"math"
-	"unsafe"
 
 	"github.com/shamaton/msgpack/v2/def"
 )
 
 func (e *encoder) calcString(v string) int {
-	// NOTE : unsafe
-	strBytes := *(*[]byte)(unsafe.Pointer(&v))
-	l := len(strBytes)
+	l := len(v)
 	if l < 32 {
 		return l
 	} else if l <= math.MaxUint8 {
@@ -20,7 +17,6 @@ func (e *encoder) calcString(v string) int {
 		return def.Byte2 + l
 	}
 	return def.Byte4 + l
-	// NOTE : length over uint32
 }
 
 func (e *encoder) writeString(str string, writer io.Writer) (err error) {

--- a/internal/encoding/string.go
+++ b/internal/encoding/string.go
@@ -1,7 +1,6 @@
 package encoding
 
 import (
-	"io"
 	"math"
 
 	"github.com/shamaton/msgpack/v2/def"
@@ -58,6 +57,6 @@ func (e *encoder) writeString(str string, writer Writer) (err error) {
 		}
 	}
 
-	_, err = io.WriteString(writer, str)
+	_, err = writer.WriteString(str)
 	return err
 }

--- a/internal/encoding/struct.go
+++ b/internal/encoding/struct.go
@@ -2,7 +2,6 @@ package encoding
 
 import (
 	"fmt"
-	"io"
 	"math"
 	"reflect"
 	"sync"
@@ -20,7 +19,7 @@ type structCache struct {
 var cachemap = sync.Map{}
 
 type structCalcFunc func(rv reflect.Value) (int, error)
-type structWriteFunc func(rv reflect.Value, writer io.Writer) error
+type structWriteFunc func(rv reflect.Value, writer Writer) error
 
 func (e *encoder) getStructCalc(typ reflect.Type) structCalcFunc {
 
@@ -173,7 +172,7 @@ func (e *encoder) cacheStructMap(rv reflect.Value, ret int, t reflect.Type) (*st
 func (e *encoder) getStructWriter(typ reflect.Type) structWriteFunc {
 	for i := range extCoders {
 		if extCoders[i].Type() == typ {
-			return func(rv reflect.Value, writer io.Writer) error {
+			return func(rv reflect.Value, writer Writer) error {
 				return extCoders[i].WriteToBytes(rv, writer)
 			}
 		}
@@ -185,7 +184,7 @@ func (e *encoder) getStructWriter(typ reflect.Type) structWriteFunc {
 	return e.writeStructMap
 }
 
-func (e *encoder) writeStruct(rv reflect.Value, writer io.Writer) error {
+func (e *encoder) writeStruct(rv reflect.Value, writer Writer) error {
 	/*
 		if isTime, tm := e.isDateTime(rv); isTime {
 			return e.writeTime(tm, offset)
@@ -204,7 +203,7 @@ func (e *encoder) writeStruct(rv reflect.Value, writer io.Writer) error {
 	return e.writeStructMap(rv, writer)
 }
 
-func (e *encoder) writeStructArray(rv reflect.Value, writer io.Writer) error {
+func (e *encoder) writeStructArray(rv reflect.Value, writer Writer) error {
 	cache, find := cachemap.Load(rv.Type())
 	if !find {
 		var err error
@@ -252,7 +251,7 @@ func (e *encoder) writeStructArray(rv reflect.Value, writer io.Writer) error {
 	return nil
 }
 
-func (e *encoder) writeStructMap(rv reflect.Value, writer io.Writer) error {
+func (e *encoder) writeStructMap(rv reflect.Value, writer Writer) error {
 	cache, find := cachemap.Load(rv.Type())
 	if !find {
 		var err error

--- a/internal/encoding/uint.go
+++ b/internal/encoding/uint.go
@@ -1,7 +1,6 @@
 package encoding
 
 import (
-	"io"
 	"math"
 
 	"github.com/shamaton/msgpack/v2/def"
@@ -21,7 +20,7 @@ func (e *encoder) calcUint(v uint64) int {
 	return def.Byte8
 }
 
-func (e *encoder) writeUint(v uint64, writer io.Writer) error {
+func (e *encoder) writeUint(v uint64, writer Writer) error {
 	if v <= math.MaxInt8 {
 		return e.setByte1Uint64(v, writer)
 	}

--- a/internal/encoding/uint.go
+++ b/internal/encoding/uint.go
@@ -1,6 +1,7 @@
 package encoding
 
 import (
+	"io"
 	"math"
 
 	"github.com/shamaton/msgpack/v2/def"
@@ -20,21 +21,42 @@ func (e *encoder) calcUint(v uint64) int {
 	return def.Byte8
 }
 
-func (e *encoder) writeUint(v uint64, offset int) int {
+func (e *encoder) writeUint(v uint64, writer io.Writer) error {
 	if v <= math.MaxInt8 {
-		offset = e.setByte1Uint64(v, offset)
-	} else if v <= math.MaxUint8 {
-		offset = e.setByte1Int(def.Uint8, offset)
-		offset = e.setByte1Uint64(v, offset)
-	} else if v <= math.MaxUint16 {
-		offset = e.setByte1Int(def.Uint16, offset)
-		offset = e.setByte2Uint64(v, offset)
-	} else if v <= math.MaxUint32 {
-		offset = e.setByte1Int(def.Uint32, offset)
-		offset = e.setByte4Uint64(v, offset)
-	} else {
-		offset = e.setByte1Int(def.Uint64, offset)
-		offset = e.setByte8Uint64(v, offset)
+		return e.setByte1Uint64(v, writer)
 	}
-	return offset
+
+	if v <= math.MaxUint8 {
+		err := e.setByte1Int(def.Uint8, writer)
+		if err != nil {
+			return err
+		}
+
+		return e.setByte1Uint64(v, writer)
+	}
+
+	if v <= math.MaxUint16 {
+		err := e.setByte1Int(def.Uint16, writer)
+		if err != nil {
+			return err
+		}
+
+		return e.setByte2Uint64(v, writer)
+	}
+
+	if v <= math.MaxUint32 {
+		err := e.setByte1Int(def.Uint32, writer)
+		if err != nil {
+			return err
+		}
+
+		return e.setByte4Uint64(v, writer)
+	}
+
+	err := e.setByte1Int(def.Uint64, writer)
+	if err != nil {
+		return err
+	}
+
+	return e.setByte8Uint64(v, writer)
 }

--- a/msgpack.go
+++ b/msgpack.go
@@ -44,8 +44,8 @@ type Decoder struct {
 }
 
 // NewDecoder will create an Decoder that will decode values from a stream one at a time
-func NewDecoder(output io.Reader) *Decoder {
-	return &Decoder{reader: output}
+func NewDecoder(input io.Reader) *Decoder {
+	return &Decoder{reader: input}
 }
 
 func (e *Decoder) Decode(v interface{}) error {

--- a/msgpack.go
+++ b/msgpack.go
@@ -29,10 +29,12 @@ type Encoder struct {
 	writer io.Writer
 }
 
+// NewEncoder will create an Encoder that will encode values into a stream
 func NewEncoder(output io.Writer) *Encoder {
 	return &Encoder{writer: output}
 }
 
+// Encode a single value into the output stream
 func (e *Encoder) Encode(v interface{}) error {
 	return encoding.Encode(v, e.writer, StructAsArray)
 }
@@ -41,6 +43,7 @@ type Decoder struct {
 	reader io.Reader
 }
 
+// NewDecoder will create an Decoder that will decode values from a stream one at a time
 func NewDecoder(output io.Reader) *Decoder {
 	return &Decoder{reader: output}
 }

--- a/msgpack.go
+++ b/msgpack.go
@@ -42,8 +42,8 @@ func (e Encoder) Encode(v interface{}) error {
 	return encoding.Encode(v, e.writer, e.StructAsArray)
 }
 
-func (e Encoder) WithStructAsArray() Encoder {
-	e.StructAsArray = true
+func (e Encoder) WithStructAsArray(structAsArray bool) Encoder {
+	e.StructAsArray = structAsArray
 	return e
 }
 
@@ -70,13 +70,13 @@ func (d Decoder) Decode(v interface{}) error {
 	return decoding.Decode(d.reader, v, d.StructAsArray, d.InternStrings)
 }
 
-func (d Decoder) WithStructAsArray() Decoder {
-	d.StructAsArray = true
+func (d Decoder) WithStructAsArray(structAsArray bool) Decoder {
+	d.StructAsArray = structAsArray
 	return d
 }
 
-func (d Decoder) WithInternStrings() Decoder {
-	d.InternStrings = true
+func (d Decoder) WithInternStrings(internStrings bool) Decoder {
+	d.InternStrings = internStrings
 	return d
 }
 

--- a/msgpack.go
+++ b/msgpack.go
@@ -2,6 +2,7 @@ package msgpack
 
 import (
 	"fmt"
+	"io"
 
 	"github.com/shamaton/msgpack/v2/def"
 	"github.com/shamaton/msgpack/v2/ext"
@@ -22,6 +23,30 @@ func Marshal(v interface{}) ([]byte, error) {
 // the result into the pointer of v.
 func Unmarshal(data []byte, v interface{}) error {
 	return decoding.DecodeBytes(data, v, StructAsArray)
+}
+
+type Encoder struct {
+	writer io.Writer
+}
+
+func NewEncoder(output io.Writer) *Encoder {
+	return &Encoder{writer: output}
+}
+
+func (e *Encoder) Encode(v interface{}) error {
+	return encoding.Encode(v, e.writer, StructAsArray)
+}
+
+type Decoder struct {
+	reader io.Reader
+}
+
+func NewDecoder(output io.Reader) *Decoder {
+	return &Decoder{reader: output}
+}
+
+func (e *Decoder) Decode(v interface{}) error {
+	return decoding.Decode(e.reader, v, StructAsArray)
 }
 
 // AddExtCoder adds encoders for extension types.

--- a/msgpack.go
+++ b/msgpack.go
@@ -15,7 +15,7 @@ var StructAsArray = false
 
 // Marshal returns the MessagePack-encoded byte array of v.
 func Marshal(v interface{}) ([]byte, error) {
-	return encoding.Encode(v, StructAsArray)
+	return encoding.EncodeBytes(v, StructAsArray)
 }
 
 // Unmarshal analyzes the MessagePack-encoded data and stores

--- a/msgpack.go
+++ b/msgpack.go
@@ -21,7 +21,7 @@ func Marshal(v interface{}) ([]byte, error) {
 // Unmarshal analyzes the MessagePack-encoded data and stores
 // the result into the pointer of v.
 func Unmarshal(data []byte, v interface{}) error {
-	return decoding.Decode(data, v, StructAsArray)
+	return decoding.DecodeBytes(data, v, StructAsArray)
 }
 
 // AddExtCoder adds encoders for extension types.

--- a/msgpack_test.go
+++ b/msgpack_test.go
@@ -2024,7 +2024,7 @@ type ExtInt ExtStruct
 
 var decoder = new(testDecoder)
 
-type testDecoder struct {}
+type testDecoder struct{}
 
 var extIntCode = int8(-2)
 
@@ -2040,7 +2040,7 @@ func (td *testDecoder) AsValue(data []byte, k reflect.Kind) (interface{}, error)
 	}
 
 	switch len(data) {
-	case 15+15+10+3:
+	case 15 + 15 + 10 + 3:
 		i8 := readN(1)[0]
 		i16 := readN(2)
 		i32 := readN(4)
@@ -2179,7 +2179,7 @@ type Ext2Struct struct {
 }
 type Ext2Int Ext2Struct
 
-type testExt2Decoder struct {}
+type testExt2Decoder struct{}
 
 func (td *testExt2Decoder) Code() int8 {
 	return 3

--- a/time/decode.go
+++ b/time/decode.go
@@ -13,7 +13,7 @@ var zero = time.Unix(0, 0)
 
 var Decoder = new(timeDecoder)
 
-type timeDecoder struct {}
+type timeDecoder struct{}
 
 func (td *timeDecoder) Code() int8 {
 	return def.TimeStamp

--- a/time/decode.go
+++ b/time/decode.go
@@ -7,69 +7,41 @@ import (
 	"time"
 
 	"github.com/shamaton/msgpack/v2/def"
-	"github.com/shamaton/msgpack/v2/ext"
 )
 
 var zero = time.Unix(0, 0)
 
 var Decoder = new(timeDecoder)
 
-type timeDecoder struct {
-	ext.DecoderCommon
-}
+type timeDecoder struct {}
 
 func (td *timeDecoder) Code() int8 {
 	return def.TimeStamp
 }
 
-func (td *timeDecoder) IsType(offset int, d *[]byte) bool {
-	code, offset := td.ReadSize1(offset, d)
+func (td *timeDecoder) AsValue(data []byte, k reflect.Kind) (interface{}, error) {
+	switch len(data) {
+	case 4:
+		return time.Unix(int64(binary.BigEndian.Uint32(data)), 0), nil
 
-	if code == def.Fixext4 {
-		t, _ := td.ReadSize1(offset, d)
-		return int8(t) == td.Code()
-	} else if code == def.Fixext8 {
-		t, _ := td.ReadSize1(offset, d)
-		return int8(t) == td.Code()
-	} else if code == def.Ext8 {
-		l, offset := td.ReadSize1(offset, d)
-		t, _ := td.ReadSize1(offset, d)
-		return l == 12 && int8(t) == td.Code()
-	}
-	return false
-}
-
-func (td *timeDecoder) AsValue(offset int, k reflect.Kind, d *[]byte) (interface{}, int, error) {
-	code, offset := td.ReadSize1(offset, d)
-
-	switch code {
-	case def.Fixext4:
-		_, offset = td.ReadSize1(offset, d)
-		bs, offset := td.ReadSize4(offset, d)
-		return time.Unix(int64(binary.BigEndian.Uint32(bs)), 0), offset, nil
-
-	case def.Fixext8:
-		_, offset = td.ReadSize1(offset, d)
-		bs, offset := td.ReadSize8(offset, d)
-		data64 := binary.BigEndian.Uint64(bs)
+	case 8:
+		data64 := binary.BigEndian.Uint64(data)
 		nano := int64(data64 >> 34)
 		if nano > 999999999 {
-			return zero, 0, fmt.Errorf("In timestamp 64 formats, nanoseconds must not be larger than 999999999 : %d", nano)
+			return zero, fmt.Errorf("In timestamp 64 formats, nanoseconds must not be larger than 999999999 : %d", nano)
 		}
-		return time.Unix(int64(data64&0x00000003ffffffff), nano), offset, nil
+		return time.Unix(int64(data64&0x00000003ffffffff), nano), nil
 
-	case def.Ext8:
-		_, offset = td.ReadSize1(offset, d)
-		_, offset = td.ReadSize1(offset, d)
-		nanobs, offset := td.ReadSize4(offset, d)
-		secbs, offset := td.ReadSize8(offset, d)
+	case 12:
+		nanobs := data[:4]
+		secbs := data[4:]
 		nano := binary.BigEndian.Uint32(nanobs)
 		if nano > 999999999 {
-			return zero, 0, fmt.Errorf("In timestamp 96 formats, nanoseconds must not be larger than 999999999 : %d", nano)
+			return zero, fmt.Errorf("In timestamp 96 formats, nanoseconds must not be larger than 999999999 : %d", nano)
 		}
 		sec := binary.BigEndian.Uint64(secbs)
-		return time.Unix(int64(sec), int64(nano)), offset, nil
+		return time.Unix(int64(sec), int64(nano)), nil
 	}
 
-	return zero, 0, fmt.Errorf("should not reach this line!! code %x decoding %v", code, k)
+	return zero, fmt.Errorf("should not reach this line!! data %x decoding %v", data, k)
 }


### PR DESCRIPTION
I know this is a huge PR, but this PR theoretically solves a major pain point I've been experiencing with very large messagepack values.

Instead of reading hundreds of megabytes into a single byte slice and decoding the entire thing all at once, this now offers an API to stream the messagepack value from storage and decode it on the fly.

Similarly, instead of encoding the entire struct into a single giant byte slice before shipping it off to storage, this allows the encoding to be done in a streaming fashion.

My application is running in an environment where it is difficult to have multiple copies in memory at the same time, and streaming will greatly alleviate memory pressure.

As it is, this PR should offer full compatibility with the previous implementation _except_ for type extensions, the API of which had to be modified to support the new mode of operation.

I actually meant to create this as a PR against my own repo since I haven't thoroughly tested it against my use case yet, but... since github decided to open it here, I wrote up this description to make the purpose of these changes more clear.