### PR TITLE
add Decoder to read stream of messages

### DIFF
--- a/decode.go
+++ b/decode.go
@@ -5,11 +5,13 @@ import "github.com/shamaton/msgpack/v2/internal/decoding"
 // UnmarshalAsMap decodes data that is encoded as map format.
 // This is the same thing that StructAsArray sets false.
 func UnmarshalAsMap(data []byte, v interface{}) error {
-	return decoding.Decode(data, v, false)
+	_, err := decoding.Decode(data, v, false, true)
+	return err
 }
 
 // UnmarshalAsArray decodes data that is encoded as array format.
 // This is the same thing that StructAsArray sets true.
 func UnmarshalAsArray(data []byte, v interface{}) error {
-	return decoding.Decode(data, v, true)
+	_, err := decoding.Decode(data, v, true, true)
+	return err
 }

--- a/msgpack.go
+++ b/msgpack.go
@@ -21,7 +21,8 @@ func Marshal(v interface{}) ([]byte, error) {
 // Unmarshal analyzes the MessagePack-encoded data and stores
 // the result into the pointer of v.
 func Unmarshal(data []byte, v interface{}) error {
-	return decoding.Decode(data, v, StructAsArray)
+	_, err := decoding.Decode(data, v, StructAsArray, true)
+	return err
 }
 
 // AddExtCoder adds encoders for extension types.


### PR DESCRIPTION
I am trying to read multiple messages appended to a file. This PR adds a poor mans version of a decoder for an io.Reader. Poor man, because it reads the full file in memory, which is good enough for my use case. I also changed the `fmt.Errorf("data is empty")` error to an io.EOF erro, which is more idiomatic go. Let me know if I should leave that out of this PR.