### PR TITLE
Add custom unmarshaling support

### DIFF
--- a/internal/decoding/decoding.go
+++ b/internal/decoding/decoding.go
@@ -39,8 +39,24 @@ func Decode(data []byte, v interface{}, asArray bool) error {
 	return err
 }
 
+type Unmarshaler interface {
+	UnmarshalMsgpack(any) error
+}
+
 func (d *decoder) decode(rv reflect.Value, offset int) (int, error) {
 	k := rv.Kind()
+	if uv, ok := rv.Interface().(Unmarshaler); ok {
+		v, o, err := d.asInterface(offset, k)
+		if err != nil {
+			return 0, err
+		}
+		err = uv.UnmarshalMsgpack(v)
+		if err != nil {
+			return 0, err
+		}
+		offset = o
+		return offset, nil
+	}
 	switch k {
 	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
 		v, o, err := d.asInt(offset, k)


### PR DESCRIPTION
This PR adds the capability to define an `UnmarshalMsgpack()` method on any type, which allows customizing how unmarshaling works.

The `UnmarshalMsgpack()` method takes a single parameter of type `any` which gets the value which would be unmarshaled into an `any` type. The method should check the type of the parameter, which can be any type that msgpack supports. The method may do anything it wishes and return any errors encountered.

One use case for this is illustrated in the tests provided, where a string composed of concatenated IP networks is received and the user wants to parse them into a slice of `net.IPNet`'s on the fly.