### PR TITLE
Fix calcuration size of Ext format

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2024 Masayuki Shamoto
+Copyright (c) 2025 Masayuki Shamoto
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 * Renaming fields via `msgpack:"field_name"`
 * Omitting fields via `msgpack:"-"`
 * Omitting empty fields via `msgpack:"field_name,omitempty"`
-* Supports extend encoder / decoder
+* Supports extend encoder / decoder [(example)](./msgpack_example_test.go)
 * Can also Encoding / Decoding struct as array
 
 ## Installation

--- a/ext/decode.go
+++ b/ext/decode.go
@@ -6,35 +6,56 @@ import (
 	"github.com/shamaton/msgpack/v2/def"
 )
 
+// Decoder defines an interface for decoding values from bytes.
+// It provides methods to get the decoder type, check if the data matches the type,
+// and convert the data into a Go value.
 type Decoder interface {
+	// Code returns the unique code representing the decoder type.
 	Code() int8
+
+	// IsType checks if the data at the given offset matches the expected type.
+	// Returns true if the type matches, false otherwise.
 	IsType(offset int, d *[]byte) bool
+
+	// AsValue decodes the data at the given offset into a Go value of the specified kind.
+	// Returns the decoded value, the new offset, and an error if decoding fails.
 	AsValue(offset int, k reflect.Kind, d *[]byte) (interface{}, int, error)
 }
 
+// DecoderCommon provides common utility methods for decoding data from bytes.
 type DecoderCommon struct {
 }
 
+// ReadSize1 reads a single byte from the given index in the byte slice.
+// Returns the byte and the new index after reading.
 func (cd *DecoderCommon) ReadSize1(index int, d *[]byte) (byte, int) {
 	rb := def.Byte1
 	return (*d)[index], index + rb
 }
 
+// ReadSize2 reads two bytes from the given index in the byte slice.
+// Returns the bytes as a slice and the new index after reading.
 func (cd *DecoderCommon) ReadSize2(index int, d *[]byte) ([]byte, int) {
 	rb := def.Byte2
 	return (*d)[index : index+rb], index + rb
 }
 
+// ReadSize4 reads four bytes from the given index in the byte slice.
+// Returns the bytes as a slice and the new index after reading.
 func (cd *DecoderCommon) ReadSize4(index int, d *[]byte) ([]byte, int) {
 	rb := def.Byte4
 	return (*d)[index : index+rb], index + rb
 }
 
+// ReadSize8 reads eight bytes from the given index in the byte slice.
+// Returns the bytes as a slice and the new index after reading.
 func (cd *DecoderCommon) ReadSize8(index int, d *[]byte) ([]byte, int) {
 	rb := def.Byte8
 	return (*d)[index : index+rb], index + rb
 }
 
+// ReadSizeN reads a specified number of bytes (n) from the given index in the byte slice.
+// Returns the bytes as a slice and the new index after reading.
 func (cd *DecoderCommon) ReadSizeN(index, n int, d *[]byte) ([]byte, int) {
 	return (*d)[index : index+n], index + n
 }

--- a/ext/decoder_stream.go
+++ b/ext/decoder_stream.go
@@ -4,8 +4,19 @@ import (
 	"reflect"
 )
 
+// StreamDecoder defines an interface for decoding streams of data.
+// It provides methods to retrieve the decoder's code, check type compatibility,
+// and convert raw data into a Go value of a specified kind.
 type StreamDecoder interface {
+	// Code returns the unique identifier for the decoder.
 	Code() int8
+
+	// IsType checks if the provided code, inner type, and data length match the expected type.
+	// Returns true if the type matches, otherwise false.
 	IsType(code byte, innerType int8, dataLength int) bool
+
+	// ToValue converts the raw data into a Go value of the specified kind.
+	// Takes the code, raw data, and the target kind as input.
+	// Returns the decoded value or an error if the conversion fails.
 	ToValue(code byte, data []byte, k reflect.Kind) (any, error)
 }

--- a/ext/encode.go
+++ b/ext/encode.go
@@ -4,27 +4,48 @@ import (
 	"reflect"
 )
 
+// Encoder defines an interface for encoding values into bytes.
+// It provides methods to get the encoding type, calculate the byte size of a value,
+// and write the encoded value into a byte slice.
 type Encoder interface {
+	// Code returns the unique code representing the encoder type.
 	Code() int8
+
+	// Type returns the reflect.Type of the value that the encoder handles.
 	Type() reflect.Type
+
+	// CalcByteSize calculates the number of bytes required to encode the given value.
+	// Returns the size and an error if the calculation fails.
 	CalcByteSize(value reflect.Value) (int, error)
+
+	// WriteToBytes encodes the given value into a byte slice starting at the specified offset.
+	// Returns the new offset after writing the bytes.
 	WriteToBytes(value reflect.Value, offset int, bytes *[]byte) int
 }
 
+// EncoderCommon provides utility methods for encoding various types of values into bytes.
+// It includes methods to encode integers and unsigned integers of different sizes,
+// as well as methods to write raw byte slices into a target byte slice.
 type EncoderCommon struct {
 }
 
+// SetByte1Int64 encodes a single byte from the given int64 value into the byte slice at the specified offset.
+// Returns the new offset after writing the byte.
 func (c *EncoderCommon) SetByte1Int64(value int64, offset int, d *[]byte) int {
 	(*d)[offset] = byte(value)
 	return offset + 1
 }
 
+// SetByte2Int64 encodes the lower two bytes of the given int64 value into the byte slice at the specified offset.
+// Returns the new offset after writing the bytes.
 func (c *EncoderCommon) SetByte2Int64(value int64, offset int, d *[]byte) int {
 	(*d)[offset+0] = byte(value >> 8)
 	(*d)[offset+1] = byte(value)
 	return offset + 2
 }
 
+// SetByte4Int64 encodes the lower four bytes of the given int64 value into the byte slice at the specified offset.
+// Returns the new offset after writing the bytes.
 func (c *EncoderCommon) SetByte4Int64(value int64, offset int, d *[]byte) int {
 	(*d)[offset+0] = byte(value >> 24)
 	(*d)[offset+1] = byte(value >> 16)
@@ -33,6 +54,8 @@ func (c *EncoderCommon) SetByte4Int64(value int64, offset int, d *[]byte) int {
 	return offset + 4
 }
 
+// SetByte8Int64 encodes all eight bytes of the given int64 value into the byte slice at the specified offset.
+// Returns the new offset after writing the bytes.
 func (c *EncoderCommon) SetByte8Int64(value int64, offset int, d *[]byte) int {
 	(*d)[offset] = byte(value >> 56)
 	(*d)[offset+1] = byte(value >> 48)
@@ -45,17 +68,23 @@ func (c *EncoderCommon) SetByte8Int64(value int64, offset int, d *[]byte) int {
 	return offset + 8
 }
 
+// SetByte1Uint64 encodes a single byte from the given uint64 value into the byte slice at the specified offset.
+// Returns the new offset after writing the byte.
 func (c *EncoderCommon) SetByte1Uint64(value uint64, offset int, d *[]byte) int {
 	(*d)[offset] = byte(value)
 	return offset + 1
 }
 
+// SetByte2Uint64 encodes the lower two bytes of the given uint64 value into the byte slice at the specified offset.
+// Returns the new offset after writing the bytes.
 func (c *EncoderCommon) SetByte2Uint64(value uint64, offset int, d *[]byte) int {
 	(*d)[offset] = byte(value >> 8)
 	(*d)[offset+1] = byte(value)
 	return offset + 2
 }
 
+// SetByte4Uint64 encodes the lower four bytes of the given uint64 value into the byte slice at the specified offset.
+// Returns the new offset after writing the bytes.
 func (c *EncoderCommon) SetByte4Uint64(value uint64, offset int, d *[]byte) int {
 	(*d)[offset] = byte(value >> 24)
 	(*d)[offset+1] = byte(value >> 16)
@@ -64,6 +93,8 @@ func (c *EncoderCommon) SetByte4Uint64(value uint64, offset int, d *[]byte) int 
 	return offset + 4
 }
 
+// SetByte8Uint64 encodes all eight bytes of the given uint64 value into the byte slice at the specified offset.
+// Returns the new offset after writing the bytes.
 func (c *EncoderCommon) SetByte8Uint64(value uint64, offset int, d *[]byte) int {
 	(*d)[offset] = byte(value >> 56)
 	(*d)[offset+1] = byte(value >> 48)
@@ -76,17 +107,23 @@ func (c *EncoderCommon) SetByte8Uint64(value uint64, offset int, d *[]byte) int 
 	return offset + 8
 }
 
+// SetByte1Int encodes a single byte from the given int value into the byte slice at the specified offset.
+// Returns the new offset after writing the byte.
 func (c *EncoderCommon) SetByte1Int(code, offset int, d *[]byte) int {
 	(*d)[offset] = byte(code)
 	return offset + 1
 }
 
+// SetByte2Int encodes the lower two bytes of the given int value into the byte slice at the specified offset.
+// Returns the new offset after writing the bytes.
 func (c *EncoderCommon) SetByte2Int(value int, offset int, d *[]byte) int {
 	(*d)[offset] = byte(value >> 8)
 	(*d)[offset+1] = byte(value)
 	return offset + 2
 }
 
+// SetByte4Int encodes the lower four bytes of the given int value into the byte slice at the specified offset.
+// Returns the new offset after writing the bytes.
 func (c *EncoderCommon) SetByte4Int(value int, offset int, d *[]byte) int {
 	(*d)[offset] = byte(value >> 24)
 	(*d)[offset+1] = byte(value >> 16)
@@ -95,6 +132,8 @@ func (c *EncoderCommon) SetByte4Int(value int, offset int, d *[]byte) int {
 	return offset + 4
 }
 
+// SetByte4Uint32 encodes the lower four bytes of the given uint32 value into the byte slice at the specified offset.
+// Returns the new offset after writing the bytes.
 func (c *EncoderCommon) SetByte4Uint32(value uint32, offset int, d *[]byte) int {
 	(*d)[offset] = byte(value >> 24)
 	(*d)[offset+1] = byte(value >> 16)
@@ -103,6 +142,8 @@ func (c *EncoderCommon) SetByte4Uint32(value uint32, offset int, d *[]byte) int 
 	return offset + 4
 }
 
+// SetBytes writes the given byte slice `bs` into the target byte slice at the specified offset.
+// Returns the new offset after writing the bytes.
 func (c *EncoderCommon) SetBytes(bs []byte, offset int, d *[]byte) int {
 	for i := range bs {
 		(*d)[offset+i] = bs[i]

--- a/ext/encode_stream.go
+++ b/ext/encode_stream.go
@@ -7,29 +7,37 @@ import (
 	"github.com/shamaton/msgpack/v2/internal/common"
 )
 
-// StreamEncoder is interface that extended encoder should implement
+// StreamEncoder is an interface that extended encoders should implement.
+// It defines methods for encoding data into a stream.
 type StreamEncoder interface {
+	// Code returns the unique code for the encoder.
 	Code() int8
+	// Type returns the reflect.Type of the value being encoded.
 	Type() reflect.Type
+	// Write encodes the given value and writes it to the provided StreamWriter.
 	Write(w StreamWriter, value reflect.Value) error
 }
 
-// StreamWriter is provided some writing functions for extended format by user
+// StreamWriter provides methods for writing data in extended formats.
+// It wraps an io.Writer and a buffer for efficient writing.
 type StreamWriter struct {
-	w   io.Writer
-	buf *common.Buffer
+	w   io.Writer      // The underlying writer to write data to.
+	buf *common.Buffer // A buffer used for temporary storage during writing.
 }
 
+// CreateStreamWriter creates and returns a new StreamWriter instance.
 func CreateStreamWriter(w io.Writer, buf *common.Buffer) StreamWriter {
 	return StreamWriter{w, buf}
 }
 
+// WriteByte1Int64 writes a single byte representation of an int64 value.
 func (w *StreamWriter) WriteByte1Int64(value int64) error {
 	return w.buf.Write(w.w,
 		byte(value),
 	)
 }
 
+// WriteByte2Int64 writes a two-byte representation of an int64 value.
 func (w *StreamWriter) WriteByte2Int64(value int64) error {
 	return w.buf.Write(w.w,
 		byte(value>>8),
@@ -37,6 +45,7 @@ func (w *StreamWriter) WriteByte2Int64(value int64) error {
 	)
 }
 
+// WriteByte4Int64 writes a four-byte representation of an int64 value.
 func (w *StreamWriter) WriteByte4Int64(value int64) error {
 	return w.buf.Write(w.w,
 		byte(value>>24),
@@ -46,6 +55,7 @@ func (w *StreamWriter) WriteByte4Int64(value int64) error {
 	)
 }
 
+// WriteByte8Int64 writes an eight-byte representation of an int64 value.
 func (w *StreamWriter) WriteByte8Int64(value int64) error {
 	return w.buf.Write(w.w,
 		byte(value>>56),
@@ -59,12 +69,14 @@ func (w *StreamWriter) WriteByte8Int64(value int64) error {
 	)
 }
 
+// WriteByte1Uint64 writes a single byte representation of a uint64 value.
 func (w *StreamWriter) WriteByte1Uint64(value uint64) error {
 	return w.buf.Write(w.w,
 		byte(value),
 	)
 }
 
+// WriteByte2Uint64 writes a two-byte representation of a uint64 value.
 func (w *StreamWriter) WriteByte2Uint64(value uint64) error {
 	return w.buf.Write(w.w,
 		byte(value>>8),
@@ -72,6 +84,7 @@ func (w *StreamWriter) WriteByte2Uint64(value uint64) error {
 	)
 }
 
+// WriteByte4Uint64 writes a four-byte representation of a uint64 value.
 func (w *StreamWriter) WriteByte4Uint64(value uint64) error {
 	return w.buf.Write(w.w,
 		byte(value>>24),
@@ -81,6 +94,7 @@ func (w *StreamWriter) WriteByte4Uint64(value uint64) error {
 	)
 }
 
+// WriteByte8Uint64 writes an eight-byte representation of a uint64 value.
 func (w *StreamWriter) WriteByte8Uint64(value uint64) error {
 	return w.buf.Write(w.w,
 		byte(value>>56),
@@ -94,12 +108,14 @@ func (w *StreamWriter) WriteByte8Uint64(value uint64) error {
 	)
 }
 
+// WriteByte1Int writes a single byte representation of an int value.
 func (w *StreamWriter) WriteByte1Int(value int) error {
 	return w.buf.Write(w.w,
 		byte(value),
 	)
 }
 
+// WriteByte2Int writes a two-byte representation of an int value.
 func (w *StreamWriter) WriteByte2Int(value int) error {
 	return w.buf.Write(w.w,
 		byte(value>>8),
@@ -107,6 +123,7 @@ func (w *StreamWriter) WriteByte2Int(value int) error {
 	)
 }
 
+// WriteByte4Int writes a four-byte representation of an int value.
 func (w *StreamWriter) WriteByte4Int(value int) error {
 	return w.buf.Write(w.w,
 		byte(value>>24),
@@ -116,6 +133,7 @@ func (w *StreamWriter) WriteByte4Int(value int) error {
 	)
 }
 
+// WriteByte4Uint32 writes a four-byte representation of a uint32 value.
 func (w *StreamWriter) WriteByte4Uint32(value uint32) error {
 	return w.buf.Write(w.w,
 		byte(value>>24),
@@ -125,6 +143,7 @@ func (w *StreamWriter) WriteByte4Uint32(value uint32) error {
 	)
 }
 
+// WriteBytes writes a slice of bytes to the underlying writer.
 func (w *StreamWriter) WriteBytes(bs []byte) error {
 	return w.buf.Write(w.w, bs...)
 }

--- a/internal/encoding/byte.go
+++ b/internal/encoding/byte.go
@@ -16,11 +16,11 @@ func (e *encoder) isByteSlice(rv reflect.Value) bool {
 
 func (e *encoder) calcByteSlice(l int) (int, error) {
 	if l <= math.MaxUint8 {
-		return def.Byte1 + l, nil
+		return def.Byte1 + def.Byte1 + l, nil
 	} else if l <= math.MaxUint16 {
-		return def.Byte2 + l, nil
+		return def.Byte1 + def.Byte2 + l, nil
 	} else if uint(l) <= math.MaxUint32 {
-		return def.Byte4 + l, nil
+		return def.Byte1 + def.Byte4 + l, nil
 	}
 	// not supported error
 	return 0, fmt.Errorf("%w slice length : %d", def.ErrUnsupportedType, l)

--- a/internal/encoding/byte_test.go
+++ b/internal/encoding/byte_test.go
@@ -19,17 +19,17 @@ func Test_calcByteSlice(t *testing.T) {
 		{
 			name:   "u8",
 			value:  math.MaxUint8,
-			result: def.Byte1 + math.MaxUint8,
+			result: def.Byte1 + def.Byte1 + math.MaxUint8,
 		},
 		{
 			name:   "u16",
 			value:  math.MaxUint16,
-			result: def.Byte2 + math.MaxUint16,
+			result: def.Byte1 + def.Byte2 + math.MaxUint16,
 		},
 		{
 			name:   "u32",
 			value:  math.MaxUint32,
-			result: def.Byte4 + math.MaxUint32,
+			result: def.Byte1 + def.Byte4 + math.MaxUint32,
 		},
 		{
 			name:  "u32over",

--- a/internal/encoding/complex.go
+++ b/internal/encoding/complex.go
@@ -7,11 +7,11 @@ import (
 )
 
 func (e *encoder) calcComplex64() int {
-	return def.Byte1 + def.Byte8
+	return def.Byte1 + def.Byte1 + def.Byte8
 }
 
 func (e *encoder) calcComplex128() int {
-	return def.Byte1 + def.Byte16
+	return def.Byte1 + def.Byte1 + def.Byte16
 }
 
 func (e *encoder) writeComplex64(v complex64, offset int) int {

--- a/internal/encoding/encoding_test.go
+++ b/internal/encoding/encoding_test.go
@@ -223,3 +223,46 @@ func Test_encode(t *testing.T) {
 		f(testcases, t)
 	})
 }
+
+func Test_calcLength(t *testing.T) {
+	e := encoder{}
+
+	testcases := []struct {
+		name   string
+		length int
+		size   int
+		err    error
+	}{
+		{
+			name:   "0x0f",
+			length: 0x0f,
+			size:   def.Byte1,
+			err:    nil,
+		},
+		{
+			name:   "MaxUint16",
+			length: math.MaxUint16,
+			size:   def.Byte1 + def.Byte2,
+			err:    nil,
+		},
+		{
+			name:   "MaxUint32",
+			length: math.MaxUint32,
+			size:   def.Byte1 + def.Byte4,
+			err:    nil,
+		},
+		{
+			name:   "error",
+			length: math.MaxUint32 + 1,
+			size:   0,
+			err:    def.ErrUnsupportedLength,
+		},
+	}
+	for _, tc := range testcases {
+		t.Run(tc.name, func(t *testing.T) {
+			size, err := e.calcLength(tc.length)
+			tu.IsError(t, err, tc.err)
+			tu.Equal(t, size, tc.size)
+		})
+	}
+}

--- a/internal/encoding/float.go
+++ b/internal/encoding/float.go
@@ -6,12 +6,12 @@ import (
 	"github.com/shamaton/msgpack/v2/def"
 )
 
-func (e *encoder) calcFloat32(v float64) int {
-	return def.Byte4
+func (e *encoder) calcFloat32(_ float64) int {
+	return def.Byte1 + def.Byte4
 }
 
-func (e *encoder) calcFloat64(v float64) int {
-	return def.Byte8
+func (e *encoder) calcFloat64(_ float64) int {
+	return def.Byte1 + def.Byte8
 }
 
 func (e *encoder) writeFloat32(v float64, offset int) int {

--- a/internal/encoding/int.go
+++ b/internal/encoding/int.go
@@ -15,15 +15,15 @@ func (e *encoder) calcInt(v int64) int {
 		return e.calcUint(uint64(v))
 	} else if e.isNegativeFixInt64(v) {
 		// format code only
-		return 0
-	} else if v >= math.MinInt8 {
 		return def.Byte1
+	} else if v >= math.MinInt8 {
+		return def.Byte1 + def.Byte1
 	} else if v >= math.MinInt16 {
-		return def.Byte2
+		return def.Byte1 + def.Byte2
 	} else if v >= math.MinInt32 {
-		return def.Byte4
+		return def.Byte1 + def.Byte4
 	}
-	return def.Byte8
+	return def.Byte1 + def.Byte8
 }
 
 func (e *encoder) writeInt(v int64, offset int) int {

--- a/internal/encoding/map.go
+++ b/internal/encoding/map.go
@@ -8,252 +8,402 @@ import (
 )
 
 func (e *encoder) calcFixedMap(rv reflect.Value) (int, bool) {
-	size := 0
-
 	switch m := rv.Interface().(type) {
 	case map[string]int:
+		size, err := e.calcLength(len(m))
+		if err != nil {
+			return 0, false
+		}
 		for k, v := range m {
-			size += def.Byte1 + e.calcString(k)
-			size += def.Byte1 + e.calcInt(int64(v))
+			size += e.calcString(k)
+			size += e.calcInt(int64(v))
 		}
 		return size, true
 
 	case map[string]uint:
+		size, err := e.calcLength(len(m))
+		if err != nil {
+			return 0, false
+		}
 		for k, v := range m {
-			size += def.Byte1 + e.calcString(k)
-			size += def.Byte1 + e.calcUint(uint64(v))
+			size += e.calcString(k)
+			size += e.calcUint(uint64(v))
 		}
 		return size, true
 
 	case map[string]string:
+		size, err := e.calcLength(len(m))
+		if err != nil {
+			return 0, false
+		}
 		for k, v := range m {
-			size += def.Byte1 + e.calcString(k)
-			size += def.Byte1 + e.calcString(v)
+			size += e.calcString(k)
+			size += e.calcString(v)
 		}
 		return size, true
 
 	case map[string]float32:
+		size, err := e.calcLength(len(m))
+		if err != nil {
+			return 0, false
+		}
 		for k := range m {
-			size += def.Byte1 + e.calcString(k)
-			size += def.Byte1 + e.calcFloat32(0)
+			size += e.calcString(k)
+			size += e.calcFloat32(0)
 		}
 		return size, true
 
 	case map[string]float64:
+		size, err := e.calcLength(len(m))
+		if err != nil {
+			return 0, false
+		}
 		for k := range m {
-			size += def.Byte1 + e.calcString(k)
-			size += def.Byte1 + e.calcFloat64(0)
+			size += e.calcString(k)
+			size += e.calcFloat64(0)
 		}
 		return size, true
 
 	case map[string]bool:
+		size, err := e.calcLength(len(m))
+		if err != nil {
+			return 0, false
+		}
 		for k := range m {
-			size += def.Byte1 + e.calcString(k)
+			size += e.calcString(k)
 			size += def.Byte1 /*+ e.calcBool()*/
 		}
 		return size, true
 
 	case map[string]int8:
+		size, err := e.calcLength(len(m))
+		if err != nil {
+			return 0, false
+		}
 		for k, v := range m {
-			size += def.Byte1 + e.calcString(k)
-			size += def.Byte1 + e.calcInt(int64(v))
+			size += e.calcString(k)
+			size += e.calcInt(int64(v))
 		}
 		return size, true
 	case map[string]int16:
+		size, err := e.calcLength(len(m))
+		if err != nil {
+			return 0, false
+		}
 		for k, v := range m {
-			size += def.Byte1 + e.calcString(k)
-			size += def.Byte1 + e.calcInt(int64(v))
+			size += e.calcString(k)
+			size += e.calcInt(int64(v))
 		}
 		return size, true
 	case map[string]int32:
+		size, err := e.calcLength(len(m))
+		if err != nil {
+			return 0, false
+		}
 		for k, v := range m {
-			size += def.Byte1 + e.calcString(k)
-			size += def.Byte1 + e.calcInt(int64(v))
+			size += e.calcString(k)
+			size += e.calcInt(int64(v))
 		}
 		return size, true
 	case map[string]int64:
+		size, err := e.calcLength(len(m))
+		if err != nil {
+			return 0, false
+		}
 		for k, v := range m {
-			size += def.Byte1 + e.calcString(k)
-			size += def.Byte1 + e.calcInt(v)
+			size += e.calcString(k)
+			size += e.calcInt(v)
 		}
 		return size, true
 	case map[string]uint8:
+		size, err := e.calcLength(len(m))
+		if err != nil {
+			return 0, false
+		}
 		for k, v := range m {
-			size += def.Byte1 + e.calcString(k)
-			size += def.Byte1 + e.calcUint(uint64(v))
+			size += e.calcString(k)
+			size += e.calcUint(uint64(v))
 		}
 		return size, true
 	case map[string]uint16:
+		size, err := e.calcLength(len(m))
+		if err != nil {
+			return 0, false
+		}
 		for k, v := range m {
-			size += def.Byte1 + e.calcString(k)
-			size += def.Byte1 + e.calcUint(uint64(v))
+			size += e.calcString(k)
+			size += e.calcUint(uint64(v))
 		}
 		return size, true
 	case map[string]uint32:
+		size, err := e.calcLength(len(m))
+		if err != nil {
+			return 0, false
+		}
 		for k, v := range m {
-			size += def.Byte1 + e.calcString(k)
-			size += def.Byte1 + e.calcUint(uint64(v))
+			size += e.calcString(k)
+			size += e.calcUint(uint64(v))
 		}
 		return size, true
 	case map[string]uint64:
+		size, err := e.calcLength(len(m))
+		if err != nil {
+			return 0, false
+		}
 		for k, v := range m {
-			size += def.Byte1 + e.calcString(k)
-			size += def.Byte1 + e.calcUint(v)
+			size += e.calcString(k)
+			size += e.calcUint(v)
 		}
 		return size, true
 
 	case map[int]string:
+		size, err := e.calcLength(len(m))
+		if err != nil {
+			return 0, false
+		}
 		for k, v := range m {
-			size += def.Byte1 + e.calcInt(int64(k))
-			size += def.Byte1 + e.calcString(v)
+			size += e.calcInt(int64(k))
+			size += e.calcString(v)
 		}
 		return size, true
 	case map[int]bool:
+		size, err := e.calcLength(len(m))
+		if err != nil {
+			return 0, false
+		}
 		for k := range m {
-			size += def.Byte1 + e.calcInt(int64(k))
+			size += e.calcInt(int64(k))
 			size += def.Byte1 /* + e.calcBool()*/
 		}
 		return size, true
 
 	case map[uint]string:
+		size, err := e.calcLength(len(m))
+		if err != nil {
+			return 0, false
+		}
 		for k, v := range m {
-			size += def.Byte1 + e.calcUint(uint64(k))
-			size += def.Byte1 + e.calcString(v)
+			size += e.calcUint(uint64(k))
+			size += e.calcString(v)
 		}
 		return size, true
 	case map[uint]bool:
+		size, err := e.calcLength(len(m))
+		if err != nil {
+			return 0, false
+		}
 		for k := range m {
-			size += def.Byte1 + e.calcUint(uint64(k))
+			size += e.calcUint(uint64(k))
 			size += def.Byte1 /* + e.calcBool()*/
 		}
 		return size, true
 
 	case map[float32]string:
+		size, err := e.calcLength(len(m))
+		if err != nil {
+			return 0, false
+		}
 		for k, v := range m {
-			size += def.Byte1 + e.calcFloat32(float64(k))
-			size += def.Byte1 + e.calcString(v)
+			size += e.calcFloat32(float64(k))
+			size += e.calcString(v)
 		}
 		return size, true
 	case map[float32]bool:
+		size, err := e.calcLength(len(m))
+		if err != nil {
+			return 0, false
+		}
 		for k := range m {
-			size += def.Byte1 + e.calcFloat32(float64(k))
+			size += e.calcFloat32(float64(k))
 			size += def.Byte1 /* + e.calcBool()*/
 		}
 		return size, true
 
 	case map[float64]string:
+		size, err := e.calcLength(len(m))
+		if err != nil {
+			return 0, false
+		}
 		for k, v := range m {
-			size += def.Byte1 + e.calcFloat64(k)
-			size += def.Byte1 + e.calcString(v)
+			size += e.calcFloat64(k)
+			size += e.calcString(v)
 		}
 		return size, true
 	case map[float64]bool:
+		size, err := e.calcLength(len(m))
+		if err != nil {
+			return 0, false
+		}
 		for k := range m {
-			size += def.Byte1 + e.calcFloat64(k)
+			size += e.calcFloat64(k)
 			size += def.Byte1 /* + e.calcBool()*/
 		}
 		return size, true
 
 	case map[int8]string:
+		size, err := e.calcLength(len(m))
+		if err != nil {
+			return 0, false
+		}
 		for k, v := range m {
-			size += def.Byte1 + e.calcInt(int64(k))
-			size += def.Byte1 + e.calcString(v)
+			size += e.calcInt(int64(k))
+			size += e.calcString(v)
 		}
 		return size, true
 	case map[int8]bool:
+		size, err := e.calcLength(len(m))
+		if err != nil {
+			return 0, false
+		}
 		for k := range m {
-			size += def.Byte1 + e.calcInt(int64(k))
+			size += e.calcInt(int64(k))
 			size += def.Byte1 /* + e.calcBool()*/
 		}
 		return size, true
 	case map[int16]string:
+		size, err := e.calcLength(len(m))
+		if err != nil {
+			return 0, false
+		}
 		for k, v := range m {
-			size += def.Byte1 + e.calcInt(int64(k))
-			size += def.Byte1 + e.calcString(v)
+			size += e.calcInt(int64(k))
+			size += e.calcString(v)
 		}
 		return size, true
 	case map[int16]bool:
+		size, err := e.calcLength(len(m))
+		if err != nil {
+			return 0, false
+		}
 		for k := range m {
-			size += def.Byte1 + e.calcInt(int64(k))
+			size += e.calcInt(int64(k))
 			size += def.Byte1 /* + e.calcBool()*/
 		}
 		return size, true
 	case map[int32]string:
+		size, err := e.calcLength(len(m))
+		if err != nil {
+			return 0, false
+		}
 		for k, v := range m {
-			size += def.Byte1 + e.calcInt(int64(k))
-			size += def.Byte1 + e.calcString(v)
+			size += e.calcInt(int64(k))
+			size += e.calcString(v)
 		}
 		return size, true
 	case map[int32]bool:
+		size, err := e.calcLength(len(m))
+		if err != nil {
+			return 0, false
+		}
 		for k := range m {
-			size += def.Byte1 + e.calcInt(int64(k))
+			size += e.calcInt(int64(k))
 			size += def.Byte1 /* + e.calcBool()*/
 		}
 		return size, true
 	case map[int64]string:
+		size, err := e.calcLength(len(m))
+		if err != nil {
+			return 0, false
+		}
 		for k, v := range m {
-			size += def.Byte1 + e.calcInt(k)
-			size += def.Byte1 + e.calcString(v)
+			size += e.calcInt(k)
+			size += e.calcString(v)
 		}
 		return size, true
 	case map[int64]bool:
+		size, err := e.calcLength(len(m))
+		if err != nil {
+			return 0, false
+		}
 		for k := range m {
-			size += def.Byte1 + e.calcInt(k)
+			size += e.calcInt(k)
 			size += def.Byte1 /* + e.calcBool()*/
 		}
 		return size, true
 
 	case map[uint8]string:
+		size, err := e.calcLength(len(m))
+		if err != nil {
+			return 0, false
+		}
 		for k, v := range m {
-			size += def.Byte1 + e.calcUint(uint64(k))
-			size += def.Byte1 + e.calcString(v)
+			size += e.calcUint(uint64(k))
+			size += e.calcString(v)
 		}
 		return size, true
 	case map[uint8]bool:
+		size, err := e.calcLength(len(m))
+		if err != nil {
+			return 0, false
+		}
 		for k := range m {
-			size += def.Byte1 + e.calcUint(uint64(k))
+			size += e.calcUint(uint64(k))
 			size += def.Byte1 /* + e.calcBool()*/
 		}
 		return size, true
 	case map[uint16]string:
+		size, err := e.calcLength(len(m))
+		if err != nil {
+			return 0, false
+		}
 		for k, v := range m {
-			size += def.Byte1 + e.calcUint(uint64(k))
-			size += def.Byte1 + e.calcString(v)
+			size += e.calcUint(uint64(k))
+			size += e.calcString(v)
 		}
 		return size, true
 	case map[uint16]bool:
+		size, err := e.calcLength(len(m))
+		if err != nil {
+			return 0, false
+		}
 		for k := range m {
-			size += def.Byte1 + e.calcUint(uint64(k))
+			size += e.calcUint(uint64(k))
 			size += def.Byte1 /* + e.calcBool()*/
 		}
 		return size, true
 	case map[uint32]string:
+		size, err := e.calcLength(len(m))
+		if err != nil {
+			return 0, false
+		}
 		for k, v := range m {
-			size += def.Byte1 + e.calcUint(uint64(k))
-			size += def.Byte1 + e.calcString(v)
+			size += e.calcUint(uint64(k))
+			size += e.calcString(v)
 		}
 		return size, true
 	case map[uint32]bool:
+		size, err := e.calcLength(len(m))
+		if err != nil {
+			return 0, false
+		}
 		for k := range m {
-			size += def.Byte1 + e.calcUint(uint64(k))
+			size += e.calcUint(uint64(k))
 			size += def.Byte1 /* + e.calcBool()*/
 		}
 		return size, true
 	case map[uint64]string:
+		size, err := e.calcLength(len(m))
+		if err != nil {
+			return 0, false
+		}
 		for k, v := range m {
-			size += def.Byte1 + e.calcUint(k)
-			size += def.Byte1 + e.calcString(v)
+			size += e.calcUint(k)
+			size += e.calcString(v)
 		}
 		return size, true
 	case map[uint64]bool:
+		size, err := e.calcLength(len(m))
+		if err != nil {
+			return 0, false
+		}
 		for k := range m {
-			size += def.Byte1 + e.calcUint(k)
+			size += e.calcUint(k)
 			size += def.Byte1 /* + e.calcBool()*/
 		}
 		return size, true
 
 	}
-	return size, false
+	return 0, false
 }
 
 func (e *encoder) writeMapLength(l int, offset int) int {

--- a/internal/encoding/slice.go
+++ b/internal/encoding/slice.go
@@ -8,93 +8,147 @@ import (
 )
 
 func (e *encoder) calcFixedSlice(rv reflect.Value) (int, bool) {
-	size := 0
-
 	switch sli := rv.Interface().(type) {
 	case []int:
+		size, err := e.calcLength(len(sli))
+		if err != nil {
+			return 0, false
+		}
 		for _, v := range sli {
-			size += def.Byte1 + e.calcInt(int64(v))
+			size += e.calcInt(int64(v))
 		}
 		return size, true
 
 	case []uint:
+		size, err := e.calcLength(len(sli))
+		if err != nil {
+			return 0, false
+		}
 		for _, v := range sli {
-			size += def.Byte1 + e.calcUint(uint64(v))
+			size += e.calcUint(uint64(v))
 		}
 		return size, true
 
 	case []string:
+		size, err := e.calcLength(len(sli))
+		if err != nil {
+			return 0, false
+		}
 		for _, v := range sli {
-			size += def.Byte1 + e.calcString(v)
+			size += e.calcString(v)
 		}
 		return size, true
 
 	case []float32:
+		size, err := e.calcLength(len(sli))
+		if err != nil {
+			return 0, false
+		}
 		for _, v := range sli {
-			size += def.Byte1 + e.calcFloat32(float64(v))
+			size += e.calcFloat32(float64(v))
 		}
 		return size, true
 
 	case []float64:
+		size, err := e.calcLength(len(sli))
+		if err != nil {
+			return 0, false
+		}
 		for _, v := range sli {
-			size += def.Byte1 + e.calcFloat64(v)
+			size += e.calcFloat64(v)
 		}
 		return size, true
 
 	case []bool:
+		size, err := e.calcLength(len(sli))
+		if err != nil {
+			return 0, false
+		}
 		size += def.Byte1 * len(sli)
 		return size, true
 
 	case []int8:
+		size, err := e.calcLength(len(sli))
+		if err != nil {
+			return 0, false
+		}
 		for _, v := range sli {
-			size += def.Byte1 + e.calcInt(int64(v))
+			size += e.calcInt(int64(v))
 		}
 		return size, true
 
 	case []int16:
+		size, err := e.calcLength(len(sli))
+		if err != nil {
+			return 0, false
+		}
 		for _, v := range sli {
-			size += def.Byte1 + e.calcInt(int64(v))
+			size += e.calcInt(int64(v))
 		}
 		return size, true
 
 	case []int32:
+		size, err := e.calcLength(len(sli))
+		if err != nil {
+			return 0, false
+		}
 		for _, v := range sli {
-			size += def.Byte1 + e.calcInt(int64(v))
+			size += e.calcInt(int64(v))
 		}
 		return size, true
 
 	case []int64:
+		size, err := e.calcLength(len(sli))
+		if err != nil {
+			return 0, false
+		}
 		for _, v := range sli {
-			size += def.Byte1 + e.calcInt(v)
+			size += e.calcInt(v)
 		}
 		return size, true
 
 	case []uint8:
+		size, err := e.calcLength(len(sli))
+		if err != nil {
+			return 0, false
+		}
 		for _, v := range sli {
-			size += def.Byte1 + e.calcUint(uint64(v))
+			size += e.calcUint(uint64(v))
 		}
 		return size, true
 
 	case []uint16:
+		size, err := e.calcLength(len(sli))
+		if err != nil {
+			return 0, false
+		}
 		for _, v := range sli {
-			size += def.Byte1 + e.calcUint(uint64(v))
+			size += e.calcUint(uint64(v))
 		}
 		return size, true
 
 	case []uint32:
+		size, err := e.calcLength(len(sli))
+		if err != nil {
+			return 0, false
+		}
 		for _, v := range sli {
-			size += def.Byte1 + e.calcUint(uint64(v))
+			size += e.calcUint(uint64(v))
 		}
 		return size, true
 
 	case []uint64:
+		size, err := e.calcLength(len(sli))
+		if err != nil {
+			return 0, false
+		}
 		for _, v := range sli {
-			size += def.Byte1 + e.calcUint(v)
+			size += e.calcUint(v)
 		}
 		return size, true
 	}
 
-	return size, false
+	return 0, false
 }
 
 func (e *encoder) writeSliceLength(l int, offset int) int {
@@ -115,84 +169,98 @@ func (e *encoder) writeFixedSlice(rv reflect.Value, offset int) (int, bool) {
 
 	switch sli := rv.Interface().(type) {
 	case []int:
+		offset = e.writeSliceLength(len(sli), offset)
 		for _, v := range sli {
 			offset = e.writeInt(int64(v), offset)
 		}
 		return offset, true
 
 	case []uint:
+		offset = e.writeSliceLength(len(sli), offset)
 		for _, v := range sli {
 			offset = e.writeUint(uint64(v), offset)
 		}
 		return offset, true
 
 	case []string:
+		offset = e.writeSliceLength(len(sli), offset)
 		for _, v := range sli {
 			offset = e.writeString(v, offset)
 		}
 		return offset, true
 
 	case []float32:
+		offset = e.writeSliceLength(len(sli), offset)
 		for _, v := range sli {
 			offset = e.writeFloat32(float64(v), offset)
 		}
 		return offset, true
 
 	case []float64:
+		offset = e.writeSliceLength(len(sli), offset)
 		for _, v := range sli {
 			offset = e.writeFloat64(float64(v), offset)
 		}
 		return offset, true
 
 	case []bool:
+		offset = e.writeSliceLength(len(sli), offset)
 		for _, v := range sli {
 			offset = e.writeBool(v, offset)
 		}
 		return offset, true
 
 	case []int8:
+		offset = e.writeSliceLength(len(sli), offset)
 		for _, v := range sli {
 			offset = e.writeInt(int64(v), offset)
 		}
 		return offset, true
 
 	case []int16:
+		offset = e.writeSliceLength(len(sli), offset)
 		for _, v := range sli {
 			offset = e.writeInt(int64(v), offset)
 		}
 		return offset, true
 
 	case []int32:
+		offset = e.writeSliceLength(len(sli), offset)
 		for _, v := range sli {
 			offset = e.writeInt(int64(v), offset)
 		}
 		return offset, true
 
 	case []int64:
+		offset = e.writeSliceLength(len(sli), offset)
 		for _, v := range sli {
 			offset = e.writeInt(v, offset)
 		}
 		return offset, true
 
 	case []uint8:
+		offset = e.writeSliceLength(len(sli), offset)
 		for _, v := range sli {
 			offset = e.writeUint(uint64(v), offset)
 		}
 		return offset, true
 
 	case []uint16:
+		offset = e.writeSliceLength(len(sli), offset)
 		for _, v := range sli {
 			offset = e.writeUint(uint64(v), offset)
 		}
 		return offset, true
 
 	case []uint32:
+		offset = e.writeSliceLength(len(sli), offset)
 		for _, v := range sli {
 			offset = e.writeUint(uint64(v), offset)
 		}
 		return offset, true
 
 	case []uint64:
+		offset = e.writeSliceLength(len(sli), offset)
 		for _, v := range sli {
 			offset = e.writeUint(v, offset)
 		}

--- a/internal/encoding/slice_test.go
+++ b/internal/encoding/slice_test.go
@@ -14,59 +14,59 @@ func Test_FixedSlice(t *testing.T) {
 	}{
 		{
 			value: []int{-1},
-			size:  1,
-		},
-		{
-			value: []uint{1},
-			size:  1,
-		},
-		{
-			value: []string{"a"},
 			size:  2,
 		},
 		{
+			value: []uint{1},
+			size:  2,
+		},
+		{
+			value: []string{"a"},
+			size:  3,
+		},
+		{
 			value: []float32{1.23},
-			size:  5,
+			size:  6,
 		},
 		{
 			value: []float64{1.23},
-			size:  9,
+			size:  10,
 		},
 		{
 			value: []bool{true},
-			size:  1,
+			size:  2,
 		},
 		{
 			value: []int8{1},
-			size:  1,
+			size:  2,
 		},
 		{
 			value: []int16{1},
-			size:  1,
+			size:  2,
 		},
 		{
 			value: []int32{1},
-			size:  1,
+			size:  2,
 		},
 		{
 			value: []int64{1},
-			size:  1,
+			size:  2,
 		},
 		{
 			value: []uint8{1},
-			size:  1,
+			size:  2,
 		},
 		{
 			value: []uint16{1},
-			size:  1,
+			size:  2,
 		},
 		{
 			value: []uint32{1},
-			size:  1,
+			size:  2,
 		},
 		{
 			value: []uint64{1},
-			size:  1,
+			size:  2,
 		},
 	}
 	for _, tc := range testcases {

--- a/internal/encoding/string.go
+++ b/internal/encoding/string.go
@@ -12,13 +12,13 @@ func (e *encoder) calcString(v string) int {
 	strBytes := *(*[]byte)(unsafe.Pointer(&v))
 	l := len(strBytes)
 	if l < 32 {
-		return l
-	} else if l <= math.MaxUint8 {
 		return def.Byte1 + l
+	} else if l <= math.MaxUint8 {
+		return def.Byte1 + def.Byte1 + l
 	} else if l <= math.MaxUint16 {
-		return def.Byte2 + l
+		return def.Byte1 + def.Byte2 + l
 	}
-	return def.Byte4 + l
+	return def.Byte1 + def.Byte4 + l
 	// NOTE : length over uint32
 }
 

--- a/internal/encoding/struct_test.go
+++ b/internal/encoding/struct_test.go
@@ -43,17 +43,17 @@ func Test_calcStructArray(t *testing.T) {
 		{
 			name:   "0x0f",
 			value:  0x0f,
-			result: 0,
+			result: def.Byte1,
 		},
 		{
 			name:   "u16",
 			value:  math.MaxUint16,
-			result: def.Byte2,
+			result: def.Byte1 + def.Byte2,
 		},
 		{
 			name:   "u32",
 			value:  math.MaxUint16 + 1,
-			result: def.Byte4,
+			result: def.Byte1 + def.Byte4,
 		},
 		// can not run by out of memory
 		//{
@@ -108,17 +108,17 @@ func Test_calcStructMap(t *testing.T) {
 		{
 			name:   "0x0f",
 			value:  0x0f,
-			result: 0,
+			result: def.Byte1,
 		},
 		{
 			name:   "u16",
 			value:  math.MaxUint16,
-			result: def.Byte2,
+			result: def.Byte1 + def.Byte2,
 		},
 		{
 			name:   "u32",
 			value:  math.MaxUint16 + 1,
-			result: def.Byte4,
+			result: def.Byte1 + def.Byte4,
 		},
 		// can not run by out of memory
 		//{
@@ -169,7 +169,7 @@ func Test_writeStructArray(t *testing.T) {
 			size, err := e.calcStructArray(rv)
 			tu.NoError(t, err)
 
-			e.d = make([]byte, size+def.Byte1)
+			e.d = make([]byte, size)
 			result := e.writeStructArray(rv, 0)
 			tu.Equal(t, len(e.d), result)
 			tu.Equal(t, e.d[0], tc.code)
@@ -207,7 +207,7 @@ func Test_writeStructMap(t *testing.T) {
 			size, err := e.calcStructMap(rv)
 			tu.NoError(t, err)
 
-			e.d = make([]byte, size+def.Byte1)
+			e.d = make([]byte, size)
 			result := e.writeStructMap(rv, 0)
 			tu.Equal(t, len(e.d), result)
 			tu.Equal(t, e.d[0], tc.code)

--- a/internal/encoding/uint.go
+++ b/internal/encoding/uint.go
@@ -9,15 +9,15 @@ import (
 func (e *encoder) calcUint(v uint64) int {
 	if v <= math.MaxInt8 {
 		// format code only
-		return 0
-	} else if v <= math.MaxUint8 {
 		return def.Byte1
+	} else if v <= math.MaxUint8 {
+		return def.Byte1 + def.Byte1
 	} else if v <= math.MaxUint16 {
-		return def.Byte2
+		return def.Byte1 + def.Byte2
 	} else if v <= math.MaxUint32 {
-		return def.Byte4
+		return def.Byte1 + def.Byte4
 	}
-	return def.Byte8
+	return def.Byte1 + def.Byte8
 }
 
 func (e *encoder) writeUint(v uint64, offset int) int {

--- a/msgpack_example_test.go
+++ b/msgpack_example_test.go
@@ -1,0 +1,199 @@
+package msgpack_test
+
+import (
+	"bytes"
+	"fmt"
+	"net"
+	"reflect"
+
+	"github.com/shamaton/msgpack/v2"
+	"github.com/shamaton/msgpack/v2/def"
+	"github.com/shamaton/msgpack/v2/ext"
+)
+
+func ExampleAddExtCoder() {
+	err := msgpack.AddExtCoder(&IPNetEncoder{}, &IPNetDecoder{})
+	if err != nil {
+		panic(err)
+	}
+
+	v1 := net.IPNet{IP: net.IP{127, 0, 0, 1}, Mask: net.IPMask{255, 255, 255, 0}}
+	r1, err := msgpack.Marshal(v1)
+	if err != nil {
+		panic(err)
+	}
+	fmt.Printf("% 02x\n", r1)
+	// Output:
+	// c7 0c 32 31 32 37 2e 30 2e 30 2e 31 2f 32 34
+
+	var v2 net.IPNet
+	err = msgpack.Unmarshal(r1, &v2)
+	if err != nil {
+		panic(err)
+	}
+	fmt.Println(v2)
+	// Output:
+	// {127.0.0.0 ffffff00}
+}
+
+func ExampleAddExtStreamCoder() {
+	err := msgpack.AddExtStreamCoder(&IPNetStreamEncoder{}, &IPNetStreamDecoder{})
+	if err != nil {
+		panic(err)
+	}
+
+	v1 := net.IPNet{IP: net.IP{127, 0, 0, 1}, Mask: net.IPMask{255, 255, 255, 0}}
+
+	buf := bytes.Buffer{}
+	err = msgpack.MarshalWrite(&buf, v1)
+	if err != nil {
+		panic(err)
+	}
+	fmt.Printf("% 02x\n", buf.Bytes())
+	// Output:
+	// c7 0c 32 31 32 37 2e 30 2e 30 2e 31 2f 32 34
+
+	var v2 net.IPNet
+	err = msgpack.UnmarshalRead(&buf, &v2)
+	if err != nil {
+		panic(err)
+	}
+	fmt.Println(v2)
+	// Output:
+	// {127.0.0.0 ffffff00}
+}
+
+const ipNetCode = 50
+
+type IPNetDecoder struct {
+	ext.DecoderCommon
+}
+
+var _ ext.Decoder = (*IPNetDecoder)(nil)
+
+func (td *IPNetDecoder) Code() int8 {
+	return ipNetCode
+}
+
+func (td *IPNetDecoder) IsType(offset int, d *[]byte) bool {
+	code, offset := td.ReadSize1(offset, d)
+	if code == def.Ext8 {
+		_, offset = td.ReadSize1(offset, d)
+		t, _ := td.ReadSize1(offset, d)
+		return int8(t) == td.Code()
+	}
+	return false
+}
+
+func (td *IPNetDecoder) AsValue(offset int, k reflect.Kind, d *[]byte) (any, int, error) {
+	code, offset := td.ReadSize1(offset, d)
+
+	switch code {
+	case def.Ext8:
+		// size
+		size, offset := td.ReadSize1(offset, d)
+		// code
+		_, offset = td.ReadSize1(offset, d)
+		// value
+		data, offset := td.ReadSizeN(offset, int(size), d)
+
+		_, v, err := net.ParseCIDR(string(data))
+		if err != nil {
+			return net.IPNet{}, 0, fmt.Errorf("failed to parse CIDR: %w", err)
+		}
+		if v == nil {
+			return net.IPNet{}, 0, fmt.Errorf("parsed CIDR is nil")
+		}
+		return *v, offset, nil
+	}
+	return net.IPNet{}, 0, fmt.Errorf("should not reach this line!! code %x decoding %v", td.Code(), k)
+}
+
+type IPNetStreamDecoder struct{}
+
+var _ ext.StreamDecoder = (*IPNetStreamDecoder)(nil)
+
+func (td *IPNetStreamDecoder) Code() int8 {
+	return ipNetCode
+}
+
+func (td *IPNetStreamDecoder) IsType(code byte, innerType int8, _ int) bool {
+	return code == def.Ext8 && innerType == td.Code()
+}
+
+func (td *IPNetStreamDecoder) ToValue(code byte, data []byte, k reflect.Kind) (any, error) {
+	if code == def.Ext8 {
+		_, v, err := net.ParseCIDR(string(data))
+		if err != nil {
+			return net.IPNet{}, fmt.Errorf("failed to parse CIDR: %w", err)
+		}
+		if v == nil {
+			return net.IPNet{}, fmt.Errorf("parsed CIDR is nil")
+		}
+		return *v, nil
+	}
+	return net.IPNet{}, fmt.Errorf("should not reach this line!! code %x decoding %v", td.Code(), k)
+}
+
+type IPNetEncoder struct {
+	ext.EncoderCommon
+}
+
+var _ ext.Encoder = (*IPNetEncoder)(nil)
+
+func (s *IPNetEncoder) Code() int8 {
+	return ipNetCode
+}
+
+func (s *IPNetEncoder) Type() reflect.Type {
+	return reflect.TypeOf(net.IPNet{})
+}
+
+func (s *IPNetEncoder) CalcByteSize(value reflect.Value) (int, error) {
+	v := value.Interface().(net.IPNet)
+	fmt.Println(def.Byte1 + def.Byte1 + len([]byte(v.String())))
+	return def.Byte1 + def.Byte1 + def.Byte1 + len(v.String()), nil
+}
+
+func (s *IPNetEncoder) WriteToBytes(value reflect.Value, offset int, bytes *[]byte) int {
+	v := value.Interface().(net.IPNet)
+	data := v.String()
+
+	offset = s.SetByte1Int(def.Ext8, offset, bytes)
+	offset = s.SetByte1Int(len(data), offset, bytes)
+	offset = s.SetByte1Int(int(s.Code()), offset, bytes)
+	offset = s.SetBytes([]byte(data), offset, bytes)
+	return offset
+}
+
+type IPNetStreamEncoder struct{}
+
+var _ ext.StreamEncoder = (*IPNetStreamEncoder)(nil)
+
+func (s *IPNetStreamEncoder) Code() int8 {
+	return ipNetCode
+}
+
+func (s *IPNetStreamEncoder) Type() reflect.Type {
+	return reflect.TypeOf(net.IPNet{})
+}
+
+func (s *IPNetStreamEncoder) Write(w ext.StreamWriter, value reflect.Value) error {
+	v := value.Interface().(net.IPNet)
+	data := v.String()
+
+	if err := w.WriteByte1Int(def.Ext8); err != nil {
+		return err
+	}
+	if err := w.WriteByte1Int(len(data)); err != nil {
+		return err
+	}
+	if err := w.WriteByte1Int(int(s.Code())); err != nil {
+		return err
+	}
+	if err := w.WriteBytes([]byte(data)); err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/msgpack_example_test.go
+++ b/msgpack_example_test.go
@@ -22,18 +22,18 @@ func ExampleAddExtCoder() {
 	if err != nil {
 		panic(err)
 	}
-	fmt.Printf("% 02x\n", r1)
-	// Output:
-	// c7 0c 32 31 32 37 2e 30 2e 30 2e 31 2f 32 34
+	fmt.Printf("encode: % 02x\n", r1)
 
 	var v2 net.IPNet
 	err = msgpack.Unmarshal(r1, &v2)
 	if err != nil {
 		panic(err)
 	}
-	fmt.Println(v2)
+	fmt.Println("decode:", v2)
+
 	// Output:
-	// {127.0.0.0 ffffff00}
+	// encode: c7 0c 32 31 32 37 2e 30 2e 30 2e 31 2f 32 34
+	// decode: {127.0.0.0 ffffff00}
 }
 
 func ExampleAddExtStreamCoder() {
@@ -49,18 +49,18 @@ func ExampleAddExtStreamCoder() {
 	if err != nil {
 		panic(err)
 	}
-	fmt.Printf("% 02x\n", buf.Bytes())
-	// Output:
-	// c7 0c 32 31 32 37 2e 30 2e 30 2e 31 2f 32 34
+	fmt.Printf("encode: % 02x\n", buf.Bytes())
 
 	var v2 net.IPNet
 	err = msgpack.UnmarshalRead(&buf, &v2)
 	if err != nil {
 		panic(err)
 	}
-	fmt.Println(v2)
+	fmt.Println("decode:", v2)
+
 	// Output:
-	// {127.0.0.0 ffffff00}
+	// encode: c7 0c 32 31 32 37 2e 30 2e 30 2e 31 2f 32 34
+	// decode: {127.0.0.0 ffffff00}
 }
 
 const ipNetCode = 50
@@ -151,7 +151,6 @@ func (s *IPNetEncoder) Type() reflect.Type {
 
 func (s *IPNetEncoder) CalcByteSize(value reflect.Value) (int, error) {
 	v := value.Interface().(net.IPNet)
-	fmt.Println(def.Byte1 + def.Byte1 + len([]byte(v.String())))
 	return def.Byte1 + def.Byte1 + def.Byte1 + len(v.String()), nil
 }
 

--- a/msgpack_test.go
+++ b/msgpack_test.go
@@ -2223,7 +2223,7 @@ func (s *testEncoder) Type() reflect.Type {
 
 func (s *testEncoder) CalcByteSize(value reflect.Value) (int, error) {
 	t := value.Interface().(ExtInt)
-	return def.Byte1 + def.Byte1 + 15 + 15 + 10 + len(t.Bytes), nil
+	return def.Byte1 + def.Byte1 + def.Byte1 + 15 + 15 + 10 + len(t.Bytes), nil
 }
 
 func (s *testEncoder) WriteToBytes(value reflect.Value, offset int, bytes *[]byte) int {

--- a/time/encode.go
+++ b/time/encode.go
@@ -30,12 +30,12 @@ func (s *timeEncoder) CalcByteSize(value reflect.Value) (int, error) {
 	if secs>>34 == 0 {
 		data := uint64(t.Nanosecond())<<34 | secs
 		if data&0xffffffff00000000 == 0 {
-			return def.Byte1 + def.Byte4, nil
+			return def.Byte1 + def.Byte1 + def.Byte4, nil
 		}
-		return def.Byte1 + def.Byte8, nil
+		return def.Byte1 + def.Byte1 + def.Byte8, nil
 	}
 
-	return def.Byte1 + def.Byte1 + def.Byte4 + def.Byte8, nil
+	return def.Byte1 + def.Byte1 + def.Byte1 + def.Byte4 + def.Byte8, nil
 }
 
 func (s *timeEncoder) WriteToBytes(value reflect.Value, offset int, bytes *[]byte) int {


### PR DESCRIPTION
If you have already use Ext Encoder/Decoder, you must add `def.Byte1` to  your encoder's `CalcByteSize`.