### PR TITLE
Prepare v3 release: module path bump and UTC time decoding

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        go: ['1.22', '1.23', '1.24']
+        go: ['1.23', '1.24', '1.25']
     name: ${{ matrix.os }} @ Go ${{ matrix.go }}
     runs-on: ${{ matrix.os }}
     steps:
@@ -50,7 +50,7 @@ jobs:
           rm coverage.coverprofile.tmp
 
       - name: Upload coverage to Codecov
-        if: success() && matrix.go == '1.24' && matrix.os == 'ubuntu-latest'
+        if: success() && matrix.go == '1.25' && matrix.os == 'ubuntu-latest'
         uses: codecov/codecov-action@v4
         with:
           token: ${{ secrets.CODECOV_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -21,17 +21,21 @@ To keep the old behavior, use `SetDecodedTimeAsLocal()`.
 
 ## Installation
 
-Current version is **msgpack/v2**.
+Current version is **msgpack/v3**.
 ```sh
-go get -u github.com/shamaton/msgpack/v2
+go get -u github.com/shamaton/msgpack/v3
 ```
+
+### Upgrading from v2
+If you are upgrading from v2, please note the `time.Time` decoding change mentioned in the announcement above.
+To keep the v2 behavior, use `msgpack.SetDecodedTimeAsLocal()` after upgrading.
 
 ## Quick Start
 ```go
 package main
 
 import (
-  "github.com/shamaton/msgpack/v2"
+  "github.com/shamaton/msgpack/v3"
   "net/http"
 )
 

--- a/crash_test.go
+++ b/crash_test.go
@@ -8,7 +8,7 @@ import (
 	"sync"
 	"testing"
 
-	"github.com/shamaton/msgpack/v2"
+	"github.com/shamaton/msgpack/v3"
 )
 
 var crashDir = filepath.Join("testdata", "crashers")

--- a/decode.go
+++ b/decode.go
@@ -3,8 +3,8 @@ package msgpack
 import (
 	"io"
 
-	"github.com/shamaton/msgpack/v2/internal/decoding"
-	streamdecoding "github.com/shamaton/msgpack/v2/internal/stream/decoding"
+	"github.com/shamaton/msgpack/v3/internal/decoding"
+	streamdecoding "github.com/shamaton/msgpack/v3/internal/stream/decoding"
 )
 
 // UnmarshalAsMap decodes data that is encoded as map format.

--- a/encode.go
+++ b/encode.go
@@ -3,8 +3,8 @@ package msgpack
 import (
 	"io"
 
-	"github.com/shamaton/msgpack/v2/internal/encoding"
-	streamencoding "github.com/shamaton/msgpack/v2/internal/stream/encoding"
+	"github.com/shamaton/msgpack/v3/internal/encoding"
+	streamencoding "github.com/shamaton/msgpack/v3/internal/stream/encoding"
 )
 
 // MarshalAsMap encodes data as map format.

--- a/errors.go
+++ b/errors.go
@@ -1,7 +1,7 @@
 package msgpack
 
 import (
-	"github.com/shamaton/msgpack/v2/def"
+	"github.com/shamaton/msgpack/v3/def"
 )
 
 // Error is used in all msgpack error as the based error.

--- a/ext/decode.go
+++ b/ext/decode.go
@@ -3,7 +3,7 @@ package ext
 import (
 	"reflect"
 
-	"github.com/shamaton/msgpack/v2/def"
+	"github.com/shamaton/msgpack/v3/def"
 )
 
 // Decoder defines an interface for decoding values from bytes.

--- a/ext/encode_stream.go
+++ b/ext/encode_stream.go
@@ -4,7 +4,7 @@ import (
 	"io"
 	"reflect"
 
-	"github.com/shamaton/msgpack/v2/internal/common"
+	"github.com/shamaton/msgpack/v3/internal/common"
 )
 
 // StreamEncoder is an interface that extended encoders should implement.

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
-module github.com/shamaton/msgpack/v2
+module github.com/shamaton/msgpack/v3
 
-go 1.20
+go 1.23

--- a/internal/common/common_test.go
+++ b/internal/common/common_test.go
@@ -4,7 +4,7 @@ import (
 	"reflect"
 	"testing"
 
-	tu "github.com/shamaton/msgpack/v2/internal/common/testutil"
+	tu "github.com/shamaton/msgpack/v3/internal/common/testutil"
 )
 
 func TestCommon_CheckField(t *testing.T) {

--- a/internal/common/testutil/struct.go
+++ b/internal/common/testutil/struct.go
@@ -5,7 +5,7 @@ import (
 	"reflect"
 	"strconv"
 
-	"github.com/shamaton/msgpack/v2/def"
+	"github.com/shamaton/msgpack/v3/def"
 )
 
 // CreateStruct returns a struct that is made dynamically and encoded bytes.

--- a/internal/decoding/bin.go
+++ b/internal/decoding/bin.go
@@ -5,7 +5,7 @@ import (
 	"reflect"
 	"unsafe"
 
-	"github.com/shamaton/msgpack/v2/def"
+	"github.com/shamaton/msgpack/v3/def"
 )
 
 func (d *decoder) isCodeBin(v byte) bool {

--- a/internal/decoding/bin_test.go
+++ b/internal/decoding/bin_test.go
@@ -4,8 +4,8 @@ import (
 	"reflect"
 	"testing"
 
-	"github.com/shamaton/msgpack/v2/def"
-	tu "github.com/shamaton/msgpack/v2/internal/common/testutil"
+	"github.com/shamaton/msgpack/v3/def"
+	tu "github.com/shamaton/msgpack/v3/internal/common/testutil"
 )
 
 func Test_isCodeBin(t *testing.T) {

--- a/internal/decoding/bool.go
+++ b/internal/decoding/bool.go
@@ -3,7 +3,7 @@ package decoding
 import (
 	"reflect"
 
-	"github.com/shamaton/msgpack/v2/def"
+	"github.com/shamaton/msgpack/v3/def"
 )
 
 func (d *decoder) asBool(offset int, k reflect.Kind) (bool, int, error) {

--- a/internal/decoding/bool_test.go
+++ b/internal/decoding/bool_test.go
@@ -1,7 +1,7 @@
 package decoding
 
 import (
-	"github.com/shamaton/msgpack/v2/def"
+	"github.com/shamaton/msgpack/v3/def"
 	"reflect"
 	"testing"
 )

--- a/internal/decoding/complex.go
+++ b/internal/decoding/complex.go
@@ -6,7 +6,7 @@ import (
 	"math"
 	"reflect"
 
-	"github.com/shamaton/msgpack/v2/def"
+	"github.com/shamaton/msgpack/v3/def"
 )
 
 func (d *decoder) asComplex64(offset int, k reflect.Kind) (complex64, int, error) {

--- a/internal/decoding/complex_test.go
+++ b/internal/decoding/complex_test.go
@@ -4,7 +4,7 @@ import (
 	"reflect"
 	"testing"
 
-	"github.com/shamaton/msgpack/v2/def"
+	"github.com/shamaton/msgpack/v3/def"
 )
 
 func Test_asComplex64(t *testing.T) {

--- a/internal/decoding/decoding.go
+++ b/internal/decoding/decoding.go
@@ -4,8 +4,8 @@ import (
 	"fmt"
 	"reflect"
 
-	"github.com/shamaton/msgpack/v2/def"
-	"github.com/shamaton/msgpack/v2/internal/common"
+	"github.com/shamaton/msgpack/v3/def"
+	"github.com/shamaton/msgpack/v3/internal/common"
 )
 
 type decoder struct {

--- a/internal/decoding/decoding_test.go
+++ b/internal/decoding/decoding_test.go
@@ -4,8 +4,8 @@ import (
 	"reflect"
 	"testing"
 
-	"github.com/shamaton/msgpack/v2/def"
-	tu "github.com/shamaton/msgpack/v2/internal/common/testutil"
+	"github.com/shamaton/msgpack/v3/def"
+	tu "github.com/shamaton/msgpack/v3/internal/common/testutil"
 )
 
 type AsXXXTestCase[T any] struct {

--- a/internal/decoding/ext.go
+++ b/internal/decoding/ext.go
@@ -1,8 +1,8 @@
 package decoding
 
 import (
-	"github.com/shamaton/msgpack/v2/ext"
-	"github.com/shamaton/msgpack/v2/time"
+	"github.com/shamaton/msgpack/v3/ext"
+	"github.com/shamaton/msgpack/v3/time"
 )
 
 var extCoderMap = map[int8]ext.Decoder{time.Decoder.Code(): time.Decoder}

--- a/internal/decoding/ext_test.go
+++ b/internal/decoding/ext_test.go
@@ -3,8 +3,8 @@ package decoding
 import (
 	"testing"
 
-	tu "github.com/shamaton/msgpack/v2/internal/common/testutil"
-	"github.com/shamaton/msgpack/v2/time"
+	tu "github.com/shamaton/msgpack/v3/internal/common/testutil"
+	"github.com/shamaton/msgpack/v3/time"
 )
 
 func Test_AddExtDecoder(t *testing.T) {

--- a/internal/decoding/float.go
+++ b/internal/decoding/float.go
@@ -5,7 +5,7 @@ import (
 	"math"
 	"reflect"
 
-	"github.com/shamaton/msgpack/v2/def"
+	"github.com/shamaton/msgpack/v3/def"
 )
 
 func (d *decoder) asFloat32(offset int, k reflect.Kind) (float32, int, error) {

--- a/internal/decoding/float_test.go
+++ b/internal/decoding/float_test.go
@@ -4,7 +4,7 @@ import (
 	"reflect"
 	"testing"
 
-	"github.com/shamaton/msgpack/v2/def"
+	"github.com/shamaton/msgpack/v3/def"
 )
 
 func Test_asFloat32(t *testing.T) {

--- a/internal/decoding/int.go
+++ b/internal/decoding/int.go
@@ -4,7 +4,7 @@ import (
 	"encoding/binary"
 	"reflect"
 
-	"github.com/shamaton/msgpack/v2/def"
+	"github.com/shamaton/msgpack/v3/def"
 )
 
 func (d *decoder) isPositiveFixNum(v byte) bool {

--- a/internal/decoding/int_test.go
+++ b/internal/decoding/int_test.go
@@ -4,7 +4,7 @@ import (
 	"reflect"
 	"testing"
 
-	"github.com/shamaton/msgpack/v2/def"
+	"github.com/shamaton/msgpack/v3/def"
 )
 
 func Test_asInt(t *testing.T) {

--- a/internal/decoding/interface.go
+++ b/internal/decoding/interface.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"reflect"
 
-	"github.com/shamaton/msgpack/v2/def"
+	"github.com/shamaton/msgpack/v3/def"
 )
 
 func (d *decoder) asInterface(offset int, k reflect.Kind) (interface{}, int, error) {

--- a/internal/decoding/interface_test.go
+++ b/internal/decoding/interface_test.go
@@ -5,8 +5,8 @@ import (
 	"reflect"
 	"testing"
 
-	"github.com/shamaton/msgpack/v2/def"
-	"github.com/shamaton/msgpack/v2/ext"
+	"github.com/shamaton/msgpack/v3/def"
+	"github.com/shamaton/msgpack/v3/ext"
 )
 
 func Test_asInterfaceWithCode(t *testing.T) {

--- a/internal/decoding/map.go
+++ b/internal/decoding/map.go
@@ -4,7 +4,7 @@ import (
 	"encoding/binary"
 	"reflect"
 
-	"github.com/shamaton/msgpack/v2/def"
+	"github.com/shamaton/msgpack/v3/def"
 )
 
 var (

--- a/internal/decoding/map_test.go
+++ b/internal/decoding/map_test.go
@@ -6,8 +6,8 @@ import (
 	"reflect"
 	"testing"
 
-	"github.com/shamaton/msgpack/v2/def"
-	tu "github.com/shamaton/msgpack/v2/internal/common/testutil"
+	"github.com/shamaton/msgpack/v3/def"
+	tu "github.com/shamaton/msgpack/v3/internal/common/testutil"
 )
 
 func Test_mapLength(t *testing.T) {

--- a/internal/decoding/nil.go
+++ b/internal/decoding/nil.go
@@ -1,6 +1,6 @@
 package decoding
 
-import "github.com/shamaton/msgpack/v2/def"
+import "github.com/shamaton/msgpack/v3/def"
 
 func (d *decoder) isCodeNil(v byte) bool {
 	return def.Nil == v

--- a/internal/decoding/read.go
+++ b/internal/decoding/read.go
@@ -1,7 +1,7 @@
 package decoding
 
 import (
-	"github.com/shamaton/msgpack/v2/def"
+	"github.com/shamaton/msgpack/v3/def"
 )
 
 func (d *decoder) readSize1(index int) (byte, int, error) {

--- a/internal/decoding/slice.go
+++ b/internal/decoding/slice.go
@@ -4,7 +4,7 @@ import (
 	"encoding/binary"
 	"reflect"
 
-	"github.com/shamaton/msgpack/v2/def"
+	"github.com/shamaton/msgpack/v3/def"
 )
 
 var (

--- a/internal/decoding/slice_test.go
+++ b/internal/decoding/slice_test.go
@@ -5,8 +5,8 @@ import (
 	"reflect"
 	"testing"
 
-	"github.com/shamaton/msgpack/v2/def"
-	tu "github.com/shamaton/msgpack/v2/internal/common/testutil"
+	"github.com/shamaton/msgpack/v3/def"
+	tu "github.com/shamaton/msgpack/v3/internal/common/testutil"
 )
 
 func Test_sliceLength(t *testing.T) {

--- a/internal/decoding/string.go
+++ b/internal/decoding/string.go
@@ -4,7 +4,7 @@ import (
 	"encoding/binary"
 	"reflect"
 
-	"github.com/shamaton/msgpack/v2/def"
+	"github.com/shamaton/msgpack/v3/def"
 )
 
 var emptyString = ""

--- a/internal/decoding/string_test.go
+++ b/internal/decoding/string_test.go
@@ -5,7 +5,7 @@ import (
 	"reflect"
 	"testing"
 
-	"github.com/shamaton/msgpack/v2/def"
+	"github.com/shamaton/msgpack/v3/def"
 )
 
 func Test_stringByteLength(t *testing.T) {

--- a/internal/decoding/struct.go
+++ b/internal/decoding/struct.go
@@ -5,7 +5,7 @@ import (
 	"reflect"
 	"sync"
 
-	"github.com/shamaton/msgpack/v2/def"
+	"github.com/shamaton/msgpack/v3/def"
 )
 
 type structCacheTypeMap struct {

--- a/internal/decoding/struct_test.go
+++ b/internal/decoding/struct_test.go
@@ -5,8 +5,8 @@ import (
 	"testing"
 	"time"
 
-	"github.com/shamaton/msgpack/v2/def"
-	tu "github.com/shamaton/msgpack/v2/internal/common/testutil"
+	"github.com/shamaton/msgpack/v3/def"
+	tu "github.com/shamaton/msgpack/v3/internal/common/testutil"
 )
 
 func Test_setStruct_ext(t *testing.T) {

--- a/internal/decoding/uint.go
+++ b/internal/decoding/uint.go
@@ -4,7 +4,7 @@ import (
 	"encoding/binary"
 	"reflect"
 
-	"github.com/shamaton/msgpack/v2/def"
+	"github.com/shamaton/msgpack/v3/def"
 )
 
 func (d *decoder) asUint(offset int, k reflect.Kind) (uint64, int, error) {

--- a/internal/decoding/uint_test.go
+++ b/internal/decoding/uint_test.go
@@ -5,7 +5,7 @@ import (
 	"reflect"
 	"testing"
 
-	"github.com/shamaton/msgpack/v2/def"
+	"github.com/shamaton/msgpack/v3/def"
 )
 
 func Test_asUint(t *testing.T) {

--- a/internal/encoding/bool.go
+++ b/internal/encoding/bool.go
@@ -1,6 +1,6 @@
 package encoding
 
-import "github.com/shamaton/msgpack/v2/def"
+import "github.com/shamaton/msgpack/v3/def"
 
 //func (e *encoder) calcBool() int {
 //	return 0

--- a/internal/encoding/byte.go
+++ b/internal/encoding/byte.go
@@ -5,7 +5,7 @@ import (
 	"math"
 	"reflect"
 
-	"github.com/shamaton/msgpack/v2/def"
+	"github.com/shamaton/msgpack/v3/def"
 )
 
 var typeByte = reflect.TypeOf(byte(0))

--- a/internal/encoding/byte_test.go
+++ b/internal/encoding/byte_test.go
@@ -4,9 +4,9 @@ import (
 	"math"
 	"testing"
 
-	"github.com/shamaton/msgpack/v2/def"
+	"github.com/shamaton/msgpack/v3/def"
 
-	tu "github.com/shamaton/msgpack/v2/internal/common/testutil"
+	tu "github.com/shamaton/msgpack/v3/internal/common/testutil"
 )
 
 func Test_calcByteSlice(t *testing.T) {

--- a/internal/encoding/complex.go
+++ b/internal/encoding/complex.go
@@ -3,7 +3,7 @@ package encoding
 import (
 	"math"
 
-	"github.com/shamaton/msgpack/v2/def"
+	"github.com/shamaton/msgpack/v3/def"
 )
 
 func (e *encoder) calcComplex64() int {

--- a/internal/encoding/encoding.go
+++ b/internal/encoding/encoding.go
@@ -5,8 +5,8 @@ import (
 	"math"
 	"reflect"
 
-	"github.com/shamaton/msgpack/v2/def"
-	"github.com/shamaton/msgpack/v2/internal/common"
+	"github.com/shamaton/msgpack/v3/def"
+	"github.com/shamaton/msgpack/v3/internal/common"
 )
 
 type encoder struct {

--- a/internal/encoding/encoding_test.go
+++ b/internal/encoding/encoding_test.go
@@ -6,9 +6,9 @@ import (
 	"strconv"
 	"testing"
 
-	"github.com/shamaton/msgpack/v2/def"
+	"github.com/shamaton/msgpack/v3/def"
 
-	tu "github.com/shamaton/msgpack/v2/internal/common/testutil"
+	tu "github.com/shamaton/msgpack/v3/internal/common/testutil"
 )
 
 func TestEncode(t *testing.T) {

--- a/internal/encoding/ext.go
+++ b/internal/encoding/ext.go
@@ -3,8 +3,8 @@ package encoding
 import (
 	"reflect"
 
-	"github.com/shamaton/msgpack/v2/ext"
-	"github.com/shamaton/msgpack/v2/time"
+	"github.com/shamaton/msgpack/v3/ext"
+	"github.com/shamaton/msgpack/v3/time"
 )
 
 var extCoderMap = map[reflect.Type]ext.Encoder{time.Encoder.Type(): time.Encoder}

--- a/internal/encoding/ext_test.go
+++ b/internal/encoding/ext_test.go
@@ -3,8 +3,8 @@ package encoding
 import (
 	"testing"
 
-	tu "github.com/shamaton/msgpack/v2/internal/common/testutil"
-	"github.com/shamaton/msgpack/v2/time"
+	tu "github.com/shamaton/msgpack/v3/internal/common/testutil"
+	"github.com/shamaton/msgpack/v3/time"
 )
 
 func Test_AddExtEncoder(t *testing.T) {

--- a/internal/encoding/float.go
+++ b/internal/encoding/float.go
@@ -3,7 +3,7 @@ package encoding
 import (
 	"math"
 
-	"github.com/shamaton/msgpack/v2/def"
+	"github.com/shamaton/msgpack/v3/def"
 )
 
 func (e *encoder) calcFloat32(_ float64) int {

--- a/internal/encoding/int.go
+++ b/internal/encoding/int.go
@@ -3,7 +3,7 @@ package encoding
 import (
 	"math"
 
-	"github.com/shamaton/msgpack/v2/def"
+	"github.com/shamaton/msgpack/v3/def"
 )
 
 func (e *encoder) isNegativeFixInt64(v int64) bool {

--- a/internal/encoding/map.go
+++ b/internal/encoding/map.go
@@ -4,7 +4,7 @@ import (
 	"math"
 	"reflect"
 
-	"github.com/shamaton/msgpack/v2/def"
+	"github.com/shamaton/msgpack/v3/def"
 )
 
 func (e *encoder) calcFixedMap(rv reflect.Value) (int, bool) {

--- a/internal/encoding/nil.go
+++ b/internal/encoding/nil.go
@@ -1,6 +1,6 @@
 package encoding
 
-import "github.com/shamaton/msgpack/v2/def"
+import "github.com/shamaton/msgpack/v3/def"
 
 func (e *encoder) writeNil(offset int) int {
 	offset = e.setByte1Int(def.Nil, offset)

--- a/internal/encoding/slice.go
+++ b/internal/encoding/slice.go
@@ -4,7 +4,7 @@ import (
 	"math"
 	"reflect"
 
-	"github.com/shamaton/msgpack/v2/def"
+	"github.com/shamaton/msgpack/v3/def"
 )
 
 func (e *encoder) calcFixedSlice(rv reflect.Value) (int, bool) {

--- a/internal/encoding/slice_test.go
+++ b/internal/encoding/slice_test.go
@@ -4,7 +4,7 @@ import (
 	"reflect"
 	"testing"
 
-	tu "github.com/shamaton/msgpack/v2/internal/common/testutil"
+	tu "github.com/shamaton/msgpack/v3/internal/common/testutil"
 )
 
 func Test_FixedSlice(t *testing.T) {

--- a/internal/encoding/string.go
+++ b/internal/encoding/string.go
@@ -4,7 +4,7 @@ import (
 	"math"
 	"unsafe"
 
-	"github.com/shamaton/msgpack/v2/def"
+	"github.com/shamaton/msgpack/v3/def"
 )
 
 func (e *encoder) calcString(v string) int {

--- a/internal/encoding/struct.go
+++ b/internal/encoding/struct.go
@@ -5,8 +5,8 @@ import (
 	"reflect"
 	"sync"
 
-	"github.com/shamaton/msgpack/v2/def"
-	"github.com/shamaton/msgpack/v2/internal/common"
+	"github.com/shamaton/msgpack/v3/def"
+	"github.com/shamaton/msgpack/v3/internal/common"
 )
 
 type structCache struct {

--- a/internal/encoding/struct_test.go
+++ b/internal/encoding/struct_test.go
@@ -5,8 +5,8 @@ import (
 	"reflect"
 	"testing"
 
-	"github.com/shamaton/msgpack/v2/def"
-	tu "github.com/shamaton/msgpack/v2/internal/common/testutil"
+	"github.com/shamaton/msgpack/v3/def"
+	tu "github.com/shamaton/msgpack/v3/internal/common/testutil"
 )
 
 func Test_calcStructArray(t *testing.T) {

--- a/internal/encoding/uint.go
+++ b/internal/encoding/uint.go
@@ -3,7 +3,7 @@ package encoding
 import (
 	"math"
 
-	"github.com/shamaton/msgpack/v2/def"
+	"github.com/shamaton/msgpack/v3/def"
 )
 
 func (e *encoder) calcUint(v uint64) int {

--- a/internal/stream/decoding/bin.go
+++ b/internal/stream/decoding/bin.go
@@ -5,7 +5,7 @@ import (
 	"reflect"
 	"unsafe"
 
-	"github.com/shamaton/msgpack/v2/def"
+	"github.com/shamaton/msgpack/v3/def"
 )
 
 func (d *decoder) isCodeBin(v byte) bool {

--- a/internal/stream/decoding/bin_test.go
+++ b/internal/stream/decoding/bin_test.go
@@ -5,8 +5,8 @@ import (
 	"reflect"
 	"testing"
 
-	"github.com/shamaton/msgpack/v2/def"
-	tu "github.com/shamaton/msgpack/v2/internal/common/testutil"
+	"github.com/shamaton/msgpack/v3/def"
+	tu "github.com/shamaton/msgpack/v3/internal/common/testutil"
 )
 
 func Test_isCodeBin(t *testing.T) {

--- a/internal/stream/decoding/bool.go
+++ b/internal/stream/decoding/bool.go
@@ -3,7 +3,7 @@ package decoding
 import (
 	"reflect"
 
-	"github.com/shamaton/msgpack/v2/def"
+	"github.com/shamaton/msgpack/v3/def"
 )
 
 func (d *decoder) asBool(k reflect.Kind) (bool, error) {

--- a/internal/stream/decoding/bool_test.go
+++ b/internal/stream/decoding/bool_test.go
@@ -5,7 +5,7 @@ import (
 	"reflect"
 	"testing"
 
-	"github.com/shamaton/msgpack/v2/def"
+	"github.com/shamaton/msgpack/v3/def"
 )
 
 func Test_asBool(t *testing.T) {

--- a/internal/stream/decoding/complex.go
+++ b/internal/stream/decoding/complex.go
@@ -6,7 +6,7 @@ import (
 	"math"
 	"reflect"
 
-	"github.com/shamaton/msgpack/v2/def"
+	"github.com/shamaton/msgpack/v3/def"
 )
 
 func (d *decoder) asComplex64(code byte, k reflect.Kind) (complex64, error) {

--- a/internal/stream/decoding/complex_test.go
+++ b/internal/stream/decoding/complex_test.go
@@ -5,7 +5,7 @@ import (
 	"reflect"
 	"testing"
 
-	"github.com/shamaton/msgpack/v2/def"
+	"github.com/shamaton/msgpack/v3/def"
 )
 
 func Test_asComplex64(t *testing.T) {

--- a/internal/stream/decoding/decoding.go
+++ b/internal/stream/decoding/decoding.go
@@ -5,8 +5,8 @@ import (
 	"io"
 	"reflect"
 
-	"github.com/shamaton/msgpack/v2/def"
-	"github.com/shamaton/msgpack/v2/internal/common"
+	"github.com/shamaton/msgpack/v3/def"
+	"github.com/shamaton/msgpack/v3/internal/common"
 )
 
 type decoder struct {

--- a/internal/stream/decoding/decoding_test.go
+++ b/internal/stream/decoding/decoding_test.go
@@ -5,10 +5,10 @@ import (
 	"reflect"
 	"testing"
 
-	"github.com/shamaton/msgpack/v2/def"
+	"github.com/shamaton/msgpack/v3/def"
 
-	"github.com/shamaton/msgpack/v2/internal/common"
-	tu "github.com/shamaton/msgpack/v2/internal/common/testutil"
+	"github.com/shamaton/msgpack/v3/internal/common"
+	tu "github.com/shamaton/msgpack/v3/internal/common/testutil"
 )
 
 type AsXXXTestCase[T any] struct {

--- a/internal/stream/decoding/ext.go
+++ b/internal/stream/decoding/ext.go
@@ -2,9 +2,9 @@ package decoding
 
 import (
 	"encoding/binary"
-	"github.com/shamaton/msgpack/v2/def"
-	"github.com/shamaton/msgpack/v2/ext"
-	"github.com/shamaton/msgpack/v2/time"
+	"github.com/shamaton/msgpack/v3/def"
+	"github.com/shamaton/msgpack/v3/ext"
+	"github.com/shamaton/msgpack/v3/time"
 )
 
 var extCoderMap = map[int8]ext.StreamDecoder{time.StreamDecoder.Code(): time.StreamDecoder}

--- a/internal/stream/decoding/ext_test.go
+++ b/internal/stream/decoding/ext_test.go
@@ -4,10 +4,10 @@ import (
 	"io"
 	"testing"
 
-	"github.com/shamaton/msgpack/v2/def"
-	"github.com/shamaton/msgpack/v2/internal/common"
-	tu "github.com/shamaton/msgpack/v2/internal/common/testutil"
-	"github.com/shamaton/msgpack/v2/time"
+	"github.com/shamaton/msgpack/v3/def"
+	"github.com/shamaton/msgpack/v3/internal/common"
+	tu "github.com/shamaton/msgpack/v3/internal/common/testutil"
+	"github.com/shamaton/msgpack/v3/time"
 )
 
 func Test_AddExtDecoder(t *testing.T) {

--- a/internal/stream/decoding/float.go
+++ b/internal/stream/decoding/float.go
@@ -5,7 +5,7 @@ import (
 	"math"
 	"reflect"
 
-	"github.com/shamaton/msgpack/v2/def"
+	"github.com/shamaton/msgpack/v3/def"
 )
 
 func (d *decoder) asFloat32(k reflect.Kind) (float32, error) {

--- a/internal/stream/decoding/float_test.go
+++ b/internal/stream/decoding/float_test.go
@@ -5,7 +5,7 @@ import (
 	"reflect"
 	"testing"
 
-	"github.com/shamaton/msgpack/v2/def"
+	"github.com/shamaton/msgpack/v3/def"
 )
 
 func Test_asFloat32(t *testing.T) {

--- a/internal/stream/decoding/int.go
+++ b/internal/stream/decoding/int.go
@@ -4,7 +4,7 @@ import (
 	"encoding/binary"
 	"reflect"
 
-	"github.com/shamaton/msgpack/v2/def"
+	"github.com/shamaton/msgpack/v3/def"
 )
 
 func (d *decoder) isPositiveFixNum(v byte) bool {

--- a/internal/stream/decoding/int_test.go
+++ b/internal/stream/decoding/int_test.go
@@ -5,7 +5,7 @@ import (
 	"reflect"
 	"testing"
 
-	"github.com/shamaton/msgpack/v2/def"
+	"github.com/shamaton/msgpack/v3/def"
 )
 
 func Test_asInt(t *testing.T) {

--- a/internal/stream/decoding/interface.go
+++ b/internal/stream/decoding/interface.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"reflect"
 
-	"github.com/shamaton/msgpack/v2/def"
+	"github.com/shamaton/msgpack/v3/def"
 )
 
 func (d *decoder) asInterface(k reflect.Kind) (interface{}, error) {

--- a/internal/stream/decoding/interface_test.go
+++ b/internal/stream/decoding/interface_test.go
@@ -6,8 +6,8 @@ import (
 	"reflect"
 	"testing"
 
-	"github.com/shamaton/msgpack/v2/def"
-	"github.com/shamaton/msgpack/v2/ext"
+	"github.com/shamaton/msgpack/v3/def"
+	"github.com/shamaton/msgpack/v3/ext"
 )
 
 func Test_asInterface(t *testing.T) {

--- a/internal/stream/decoding/map.go
+++ b/internal/stream/decoding/map.go
@@ -4,7 +4,7 @@ import (
 	"encoding/binary"
 	"reflect"
 
-	"github.com/shamaton/msgpack/v2/def"
+	"github.com/shamaton/msgpack/v3/def"
 )
 
 var (

--- a/internal/stream/decoding/map_test.go
+++ b/internal/stream/decoding/map_test.go
@@ -7,8 +7,8 @@ import (
 	"reflect"
 	"testing"
 
-	"github.com/shamaton/msgpack/v2/def"
-	tu "github.com/shamaton/msgpack/v2/internal/common/testutil"
+	"github.com/shamaton/msgpack/v3/def"
+	tu "github.com/shamaton/msgpack/v3/internal/common/testutil"
 )
 
 func Test_mapLength(t *testing.T) {

--- a/internal/stream/decoding/nil.go
+++ b/internal/stream/decoding/nil.go
@@ -1,6 +1,6 @@
 package decoding
 
-import "github.com/shamaton/msgpack/v2/def"
+import "github.com/shamaton/msgpack/v3/def"
 
 func (d *decoder) isCodeNil(v byte) bool {
 	return def.Nil == v

--- a/internal/stream/decoding/slice.go
+++ b/internal/stream/decoding/slice.go
@@ -4,7 +4,7 @@ import (
 	"encoding/binary"
 	"reflect"
 
-	"github.com/shamaton/msgpack/v2/def"
+	"github.com/shamaton/msgpack/v3/def"
 )
 
 var (

--- a/internal/stream/decoding/slice_test.go
+++ b/internal/stream/decoding/slice_test.go
@@ -6,8 +6,8 @@ import (
 	"reflect"
 	"testing"
 
-	"github.com/shamaton/msgpack/v2/def"
-	tu "github.com/shamaton/msgpack/v2/internal/common/testutil"
+	"github.com/shamaton/msgpack/v3/def"
+	tu "github.com/shamaton/msgpack/v3/internal/common/testutil"
 )
 
 func Test_sliceLength(t *testing.T) {

--- a/internal/stream/decoding/string.go
+++ b/internal/stream/decoding/string.go
@@ -4,7 +4,7 @@ import (
 	"encoding/binary"
 	"reflect"
 
-	"github.com/shamaton/msgpack/v2/def"
+	"github.com/shamaton/msgpack/v3/def"
 )
 
 var emptyString = ""
@@ -83,7 +83,7 @@ func (d *decoder) asStringByteByLength(l int, _ reflect.Kind) ([]byte, error) {
 	if l < 1 {
 		return emptyBytes, nil
 	}
-	
+
 	// avoid common buffer reference
 	return d.copySizeN(l)
 }

--- a/internal/stream/decoding/string_test.go
+++ b/internal/stream/decoding/string_test.go
@@ -6,7 +6,7 @@ import (
 	"reflect"
 	"testing"
 
-	"github.com/shamaton/msgpack/v2/def"
+	"github.com/shamaton/msgpack/v3/def"
 )
 
 func Test_stringByteLength(t *testing.T) {

--- a/internal/stream/decoding/struct.go
+++ b/internal/stream/decoding/struct.go
@@ -5,7 +5,7 @@ import (
 	"reflect"
 	"sync"
 
-	"github.com/shamaton/msgpack/v2/def"
+	"github.com/shamaton/msgpack/v3/def"
 )
 
 type structCacheTypeMap struct {

--- a/internal/stream/decoding/struct_test.go
+++ b/internal/stream/decoding/struct_test.go
@@ -6,9 +6,9 @@ import (
 	"testing"
 	"time"
 
-	tu "github.com/shamaton/msgpack/v2/internal/common/testutil"
+	tu "github.com/shamaton/msgpack/v3/internal/common/testutil"
 
-	"github.com/shamaton/msgpack/v2/def"
+	"github.com/shamaton/msgpack/v3/def"
 )
 
 func Test_setStruct_ext(t *testing.T) {

--- a/internal/stream/decoding/uint.go
+++ b/internal/stream/decoding/uint.go
@@ -4,7 +4,7 @@ import (
 	"encoding/binary"
 	"reflect"
 
-	"github.com/shamaton/msgpack/v2/def"
+	"github.com/shamaton/msgpack/v3/def"
 )
 
 func (d *decoder) asUint(k reflect.Kind) (uint64, error) {

--- a/internal/stream/decoding/uint_test.go
+++ b/internal/stream/decoding/uint_test.go
@@ -7,9 +7,9 @@ import (
 	"reflect"
 	"testing"
 
-	"github.com/shamaton/msgpack/v2/def"
-	"github.com/shamaton/msgpack/v2/internal/common"
-	tu "github.com/shamaton/msgpack/v2/internal/common/testutil"
+	"github.com/shamaton/msgpack/v3/def"
+	"github.com/shamaton/msgpack/v3/internal/common"
+	tu "github.com/shamaton/msgpack/v3/internal/common/testutil"
 )
 
 func Test_asUint(t *testing.T) {

--- a/internal/stream/encoding/bool.go
+++ b/internal/stream/encoding/bool.go
@@ -1,6 +1,6 @@
 package encoding
 
-import "github.com/shamaton/msgpack/v2/def"
+import "github.com/shamaton/msgpack/v3/def"
 
 func (e *encoder) writeBool(v bool) error {
 	if v {

--- a/internal/stream/encoding/bool_test.go
+++ b/internal/stream/encoding/bool_test.go
@@ -3,7 +3,7 @@ package encoding
 import (
 	"testing"
 
-	"github.com/shamaton/msgpack/v2/def"
+	"github.com/shamaton/msgpack/v3/def"
 )
 
 func Test_asBool(t *testing.T) {

--- a/internal/stream/encoding/byte.go
+++ b/internal/stream/encoding/byte.go
@@ -4,7 +4,7 @@ import (
 	"math"
 	"reflect"
 
-	"github.com/shamaton/msgpack/v2/def"
+	"github.com/shamaton/msgpack/v3/def"
 )
 
 var typeByte = reflect.TypeOf(byte(0))

--- a/internal/stream/encoding/byte_test.go
+++ b/internal/stream/encoding/byte_test.go
@@ -3,7 +3,7 @@ package encoding
 import (
 	"testing"
 
-	"github.com/shamaton/msgpack/v2/def"
+	"github.com/shamaton/msgpack/v3/def"
 )
 
 func Test_writeByteSliceLength(t *testing.T) {

--- a/internal/stream/encoding/complex.go
+++ b/internal/stream/encoding/complex.go
@@ -3,7 +3,7 @@ package encoding
 import (
 	"math"
 
-	"github.com/shamaton/msgpack/v2/def"
+	"github.com/shamaton/msgpack/v3/def"
 )
 
 func (e *encoder) writeComplex64(v complex64) error {

--- a/internal/stream/encoding/complex_test.go
+++ b/internal/stream/encoding/complex_test.go
@@ -3,7 +3,7 @@ package encoding
 import (
 	"testing"
 
-	"github.com/shamaton/msgpack/v2/def"
+	"github.com/shamaton/msgpack/v3/def"
 )
 
 func Test_writeComplex64(t *testing.T) {

--- a/internal/stream/encoding/encoding.go
+++ b/internal/stream/encoding/encoding.go
@@ -5,8 +5,8 @@ import (
 	"io"
 	"reflect"
 
-	"github.com/shamaton/msgpack/v2/def"
-	"github.com/shamaton/msgpack/v2/internal/common"
+	"github.com/shamaton/msgpack/v3/def"
+	"github.com/shamaton/msgpack/v3/internal/common"
 )
 
 type encoder struct {

--- a/internal/stream/encoding/encoding_test.go
+++ b/internal/stream/encoding/encoding_test.go
@@ -7,9 +7,9 @@ import (
 	"reflect"
 	"testing"
 
-	"github.com/shamaton/msgpack/v2/def"
-	"github.com/shamaton/msgpack/v2/internal/common"
-	tu "github.com/shamaton/msgpack/v2/internal/common/testutil"
+	"github.com/shamaton/msgpack/v3/def"
+	"github.com/shamaton/msgpack/v3/internal/common"
+	tu "github.com/shamaton/msgpack/v3/internal/common/testutil"
 )
 
 const dummyByte = 0xc1

--- a/internal/stream/encoding/ext.go
+++ b/internal/stream/encoding/ext.go
@@ -3,8 +3,8 @@ package encoding
 import (
 	"reflect"
 
-	"github.com/shamaton/msgpack/v2/ext"
-	"github.com/shamaton/msgpack/v2/time"
+	"github.com/shamaton/msgpack/v3/ext"
+	"github.com/shamaton/msgpack/v3/time"
 )
 
 var extCoderMap = map[reflect.Type]ext.StreamEncoder{time.StreamEncoder.Type(): time.StreamEncoder}

--- a/internal/stream/encoding/ext_test.go
+++ b/internal/stream/encoding/ext_test.go
@@ -3,8 +3,8 @@ package encoding
 import (
 	"testing"
 
-	tu "github.com/shamaton/msgpack/v2/internal/common/testutil"
-	"github.com/shamaton/msgpack/v2/time"
+	tu "github.com/shamaton/msgpack/v3/internal/common/testutil"
+	"github.com/shamaton/msgpack/v3/time"
 )
 
 func Test_AddExtEncoder(t *testing.T) {

--- a/internal/stream/encoding/float.go
+++ b/internal/stream/encoding/float.go
@@ -3,7 +3,7 @@ package encoding
 import (
 	"math"
 
-	"github.com/shamaton/msgpack/v2/def"
+	"github.com/shamaton/msgpack/v3/def"
 )
 
 func (e *encoder) writeFloat32(v float64) error {

--- a/internal/stream/encoding/float_test.go
+++ b/internal/stream/encoding/float_test.go
@@ -3,7 +3,7 @@ package encoding
 import (
 	"testing"
 
-	"github.com/shamaton/msgpack/v2/def"
+	"github.com/shamaton/msgpack/v3/def"
 )
 
 func Test_writeFloat32(t *testing.T) {

--- a/internal/stream/encoding/int.go
+++ b/internal/stream/encoding/int.go
@@ -3,7 +3,7 @@ package encoding
 import (
 	"math"
 
-	"github.com/shamaton/msgpack/v2/def"
+	"github.com/shamaton/msgpack/v3/def"
 )
 
 func (e *encoder) isNegativeFixInt64(v int64) bool {

--- a/internal/stream/encoding/int_test.go
+++ b/internal/stream/encoding/int_test.go
@@ -4,7 +4,7 @@ import (
 	"math"
 	"testing"
 
-	"github.com/shamaton/msgpack/v2/def"
+	"github.com/shamaton/msgpack/v3/def"
 )
 
 func Test_asInt(t *testing.T) {

--- a/internal/stream/encoding/map.go
+++ b/internal/stream/encoding/map.go
@@ -4,7 +4,7 @@ import (
 	"math"
 	"reflect"
 
-	"github.com/shamaton/msgpack/v2/def"
+	"github.com/shamaton/msgpack/v3/def"
 )
 
 func (e *encoder) writeMapLength(l int) error {

--- a/internal/stream/encoding/map_test.go
+++ b/internal/stream/encoding/map_test.go
@@ -5,7 +5,7 @@ import (
 	"reflect"
 	"testing"
 
-	"github.com/shamaton/msgpack/v2/def"
+	"github.com/shamaton/msgpack/v3/def"
 )
 
 func Test_writeMapLength(t *testing.T) {

--- a/internal/stream/encoding/nil.go
+++ b/internal/stream/encoding/nil.go
@@ -1,6 +1,6 @@
 package encoding
 
-import "github.com/shamaton/msgpack/v2/def"
+import "github.com/shamaton/msgpack/v3/def"
 
 func (e *encoder) writeNil() error {
 	return e.setByte1Int(def.Nil)

--- a/internal/stream/encoding/slice.go
+++ b/internal/stream/encoding/slice.go
@@ -4,7 +4,7 @@ import (
 	"math"
 	"reflect"
 
-	"github.com/shamaton/msgpack/v2/def"
+	"github.com/shamaton/msgpack/v3/def"
 )
 
 func (e *encoder) writeSliceLength(l int) error {

--- a/internal/stream/encoding/slice_test.go
+++ b/internal/stream/encoding/slice_test.go
@@ -5,7 +5,7 @@ import (
 	"reflect"
 	"testing"
 
-	"github.com/shamaton/msgpack/v2/def"
+	"github.com/shamaton/msgpack/v3/def"
 )
 
 func Test_writeSliceLength(t *testing.T) {

--- a/internal/stream/encoding/string.go
+++ b/internal/stream/encoding/string.go
@@ -4,7 +4,7 @@ import (
 	"math"
 	"unsafe"
 
-	"github.com/shamaton/msgpack/v2/def"
+	"github.com/shamaton/msgpack/v3/def"
 )
 
 func (e *encoder) writeString(str string) error {

--- a/internal/stream/encoding/string_test.go
+++ b/internal/stream/encoding/string_test.go
@@ -5,7 +5,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/shamaton/msgpack/v2/def"
+	"github.com/shamaton/msgpack/v3/def"
 )
 
 func Test_writeString(t *testing.T) {

--- a/internal/stream/encoding/struct.go
+++ b/internal/stream/encoding/struct.go
@@ -5,9 +5,9 @@ import (
 	"reflect"
 	"sync"
 
-	"github.com/shamaton/msgpack/v2/def"
-	"github.com/shamaton/msgpack/v2/ext"
-	"github.com/shamaton/msgpack/v2/internal/common"
+	"github.com/shamaton/msgpack/v3/def"
+	"github.com/shamaton/msgpack/v3/ext"
+	"github.com/shamaton/msgpack/v3/internal/common"
 )
 
 type structCache struct {

--- a/internal/stream/encoding/struct_test.go
+++ b/internal/stream/encoding/struct_test.go
@@ -6,8 +6,8 @@ import (
 	"testing"
 	"time"
 
-	"github.com/shamaton/msgpack/v2/def"
-	tu "github.com/shamaton/msgpack/v2/internal/common/testutil"
+	"github.com/shamaton/msgpack/v3/def"
+	tu "github.com/shamaton/msgpack/v3/internal/common/testutil"
 )
 
 func Test_writeStruct(t *testing.T) {

--- a/internal/stream/encoding/uint.go
+++ b/internal/stream/encoding/uint.go
@@ -3,7 +3,7 @@ package encoding
 import (
 	"math"
 
-	"github.com/shamaton/msgpack/v2/def"
+	"github.com/shamaton/msgpack/v3/def"
 )
 
 func (e *encoder) writeUint(v uint64) error {

--- a/internal/stream/encoding/uint_test.go
+++ b/internal/stream/encoding/uint_test.go
@@ -4,7 +4,7 @@ import (
 	"math"
 	"testing"
 
-	"github.com/shamaton/msgpack/v2/def"
+	"github.com/shamaton/msgpack/v3/def"
 )
 
 func Test_asUint(t *testing.T) {

--- a/msgpack.go
+++ b/msgpack.go
@@ -4,13 +4,13 @@ import (
 	"fmt"
 	"io"
 
-	"github.com/shamaton/msgpack/v2/def"
-	"github.com/shamaton/msgpack/v2/ext"
-	"github.com/shamaton/msgpack/v2/internal/decoding"
-	"github.com/shamaton/msgpack/v2/internal/encoding"
-	streamdecoding "github.com/shamaton/msgpack/v2/internal/stream/decoding"
-	streamencoding "github.com/shamaton/msgpack/v2/internal/stream/encoding"
-	"github.com/shamaton/msgpack/v2/time"
+	"github.com/shamaton/msgpack/v3/def"
+	"github.com/shamaton/msgpack/v3/ext"
+	"github.com/shamaton/msgpack/v3/internal/decoding"
+	"github.com/shamaton/msgpack/v3/internal/encoding"
+	streamdecoding "github.com/shamaton/msgpack/v3/internal/stream/decoding"
+	streamencoding "github.com/shamaton/msgpack/v3/internal/stream/encoding"
+	"github.com/shamaton/msgpack/v3/time"
 )
 
 // StructAsArray is encoding option.

--- a/msgpack_example_test.go
+++ b/msgpack_example_test.go
@@ -6,9 +6,9 @@ import (
 	"net"
 	"reflect"
 
-	"github.com/shamaton/msgpack/v2"
-	"github.com/shamaton/msgpack/v2/def"
-	"github.com/shamaton/msgpack/v2/ext"
+	"github.com/shamaton/msgpack/v3"
+	"github.com/shamaton/msgpack/v3/def"
+	"github.com/shamaton/msgpack/v3/ext"
 )
 
 func ExampleAddExtCoder() {

--- a/msgpack_test.go
+++ b/msgpack_test.go
@@ -14,11 +14,11 @@ import (
 	"testing"
 	"time"
 
-	"github.com/shamaton/msgpack/v2"
-	"github.com/shamaton/msgpack/v2/def"
-	"github.com/shamaton/msgpack/v2/ext"
-	tu "github.com/shamaton/msgpack/v2/internal/common/testutil"
-	extTime "github.com/shamaton/msgpack/v2/time"
+	"github.com/shamaton/msgpack/v3"
+	"github.com/shamaton/msgpack/v3/def"
+	"github.com/shamaton/msgpack/v3/ext"
+	tu "github.com/shamaton/msgpack/v3/internal/common/testutil"
+	extTime "github.com/shamaton/msgpack/v3/time"
 )
 
 var now time.Time

--- a/msgpack_test.go
+++ b/msgpack_test.go
@@ -25,7 +25,7 @@ var now time.Time
 
 func init() {
 	n := time.Now()
-	now = time.Unix(n.Unix(), int64(n.Nanosecond()))
+	now = time.Unix(n.Unix(), int64(n.Nanosecond())).UTC()
 }
 
 func TestInt(t *testing.T) {
@@ -515,7 +515,7 @@ func TestAny(t *testing.T) {
 		[]byte(strings.Repeat("a", math.MaxUint16+1)),
 		[]interface{}{1, "a", 1.23}, a1, a2,
 		map[interface{}]interface{}{"1": 1, 1.23: "a"}, m1, m2,
-		time.Unix(now.Unix(), int64(now.Nanosecond())),
+		time.Unix(now.Unix(), int64(now.Nanosecond())).UTC(),
 	}
 
 	for i, v := range vars {
@@ -553,7 +553,7 @@ func TestAny(t *testing.T) {
 			{n: "Map3", v: any(map[any]any{"1": 1, 1.23: "a"})},
 			{n: "Map65535", v: any(m1)},
 			{n: "Map65536", v: any(m2)},
-			{n: "Time", v: any(time.Unix(now.Unix(), int64(now.Nanosecond())))},
+			{n: "Time", v: any(time.Unix(now.Unix(), int64(now.Nanosecond())).UTC())},
 		}
 		for i := range args {
 			i := i
@@ -1315,14 +1315,14 @@ func TestTime(t *testing.T) {
 		args := []encdecArg[time.Time]{
 			{
 				n: "Fixext4",
-				v: time.Unix(now.Unix(), 0),
+				v: time.Unix(now.Unix(), 0).UTC(),
 				c: func(d []byte) bool {
 					return d[0] == def.Fixext4
 				},
 			},
 			{
 				n: "Fixext8",
-				v: time.Unix(now.Unix(), int64(now.Nanosecond())),
+				v: time.Unix(now.Unix(), int64(now.Nanosecond())).UTC(),
 				c: func(d []byte) bool {
 					return d[0] == def.Fixext8
 				},
@@ -1376,7 +1376,25 @@ func TestTime(t *testing.T) {
 	utc8 := time.FixedZone("UTC-8", -8*60*60)
 
 	time.Local = utc8
-	defer func() { time.Local = loc }()
+	t.Cleanup(func() {
+		time.Local = loc
+		msgpack.SetDecodedTimeAsUTC()
+	})
+	t.Run("Default", func(t *testing.T) {
+		args := []encdecArg[time.Time]{
+			{
+				n: "case",
+				v: time.Unix(now.Unix(), 0),
+				vc: func(r time.Time) error {
+					tu.Equal(t, now.Unix(), r.Unix())
+					tu.Equal(t, r.Location(), time.UTC)
+					return nil
+				},
+				skipEq: true, // skip equal check because of location difference
+			},
+		}
+		encdec(t, args...)
+	})
 
 	t.Run("UTC", func(t *testing.T) {
 		msgpack.SetDecodedTimeAsUTC()

--- a/time/decode.go
+++ b/time/decode.go
@@ -6,8 +6,8 @@ import (
 	"reflect"
 	"time"
 
-	"github.com/shamaton/msgpack/v2/def"
-	"github.com/shamaton/msgpack/v2/ext"
+	"github.com/shamaton/msgpack/v3/def"
+	"github.com/shamaton/msgpack/v3/ext"
 )
 
 var zero = time.Unix(0, 0)

--- a/time/decode_stream.go
+++ b/time/decode_stream.go
@@ -6,8 +6,8 @@ import (
 	"reflect"
 	"time"
 
-	"github.com/shamaton/msgpack/v2/def"
-	"github.com/shamaton/msgpack/v2/ext"
+	"github.com/shamaton/msgpack/v3/def"
+	"github.com/shamaton/msgpack/v3/ext"
 )
 
 var StreamDecoder = new(timeStreamDecoder)

--- a/time/decode_stream_test.go
+++ b/time/decode_stream_test.go
@@ -6,8 +6,8 @@ import (
 	"testing"
 	"time"
 
-	"github.com/shamaton/msgpack/v2/def"
-	tu "github.com/shamaton/msgpack/v2/internal/common/testutil"
+	"github.com/shamaton/msgpack/v3/def"
+	tu "github.com/shamaton/msgpack/v3/internal/common/testutil"
 )
 
 func TestStreamDecodeCode(t *testing.T) {

--- a/time/decode_test.go
+++ b/time/decode_test.go
@@ -6,8 +6,8 @@ import (
 	"testing"
 	"time"
 
-	"github.com/shamaton/msgpack/v2/def"
-	tu "github.com/shamaton/msgpack/v2/internal/common/testutil"
+	"github.com/shamaton/msgpack/v3/def"
+	tu "github.com/shamaton/msgpack/v3/internal/common/testutil"
 )
 
 func TestDecodeCode(t *testing.T) {

--- a/time/encode.go
+++ b/time/encode.go
@@ -4,8 +4,8 @@ import (
 	"reflect"
 	"time"
 
-	"github.com/shamaton/msgpack/v2/def"
-	"github.com/shamaton/msgpack/v2/ext"
+	"github.com/shamaton/msgpack/v3/def"
+	"github.com/shamaton/msgpack/v3/ext"
 )
 
 var Encoder = new(timeEncoder)

--- a/time/encode_stream.go
+++ b/time/encode_stream.go
@@ -4,8 +4,8 @@ import (
 	"reflect"
 	"time"
 
-	"github.com/shamaton/msgpack/v2/def"
-	"github.com/shamaton/msgpack/v2/ext"
+	"github.com/shamaton/msgpack/v3/def"
+	"github.com/shamaton/msgpack/v3/ext"
 )
 
 var StreamEncoder = new(timeStreamEncoder)

--- a/time/encode_stream_test.go
+++ b/time/encode_stream_test.go
@@ -8,10 +8,10 @@ import (
 	"testing"
 	"time"
 
-	"github.com/shamaton/msgpack/v2/def"
-	"github.com/shamaton/msgpack/v2/ext"
-	"github.com/shamaton/msgpack/v2/internal/common"
-	tu "github.com/shamaton/msgpack/v2/internal/common/testutil"
+	"github.com/shamaton/msgpack/v3/def"
+	"github.com/shamaton/msgpack/v3/ext"
+	"github.com/shamaton/msgpack/v3/internal/common"
+	tu "github.com/shamaton/msgpack/v3/internal/common/testutil"
 )
 
 func TestStreamCode(t *testing.T) {

--- a/time/encode_test.go
+++ b/time/encode_test.go
@@ -6,8 +6,8 @@ import (
 	"testing"
 	"time"
 
-	"github.com/shamaton/msgpack/v2/def"
-	tu "github.com/shamaton/msgpack/v2/internal/common/testutil"
+	"github.com/shamaton/msgpack/v3/def"
+	tu "github.com/shamaton/msgpack/v3/internal/common/testutil"
 )
 
 func TestCode(t *testing.T) {

--- a/time/time.go
+++ b/time/time.go
@@ -1,6 +1,6 @@
 package time
 
-var decodeAsLocal = true
+var decodeAsLocal = false
 
 // SetDecodedAsLocal sets the decoded time to local time.
 func SetDecodedAsLocal(b bool) {


### PR DESCRIPTION
- Bump module path to github.com/shamaton/msgpack/v3 and update all internal imports
- Change default time.Time decode behavior to UTC and align tests to UTC
- Update README for v3 install and upgrade guidance
- Raise Go version in go.mod and CI matrix (Codecov on 1.25)