### PR TITLE
Add tagpr configuration

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,4 @@
+changelog:
+  exclude:
+    labels:
+      - tagpr

--- a/.github/workflows/tagpr.yml
+++ b/.github/workflows/tagpr.yml
@@ -1,0 +1,20 @@
+name: tagpr
+
+on:
+  push:
+    branches: ["main"]
+
+jobs:
+  tagpr:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+      issues: read
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
+      - uses: Songmu/tagpr@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.tagpr
+++ b/.tagpr
@@ -1,0 +1,7 @@
+[tagpr]
+    releaseBranch = main
+    versionFile = -
+    vPrefix = true
+    changelog = true
+    release = true
+    fixedMajorVersion = 3


### PR DESCRIPTION
## Summary
- Add tagpr workflow to automate release PR and tag creation.
- Configure tagpr for `main`, changelog generation, and v-prefixed tags.
- Exclude tagpr-labeled PRs from GitHub release changelogs.

## Background / Motivation
Automates the release flow with tagpr so release PRs, changelogs, and tags can be managed consistently from the `main` branch.

## Changes
- Add `.github/workflows/tagpr.yml` GitHub Actions workflow.
- Add `.tagpr` configuration with fixed major version `3`.
- Add `.github/release.yml` changelog exclusion for the `tagpr` label.

## Test Plan
- Not run; configuration-only change.

## Notes
- The tagpr workflow runs on pushes to `main`.