### PR TITLE
fix: backport ext frame bounds validation to v2

### DIFF
--- a/internal/decoding/decoding.go
+++ b/internal/decoding/decoding.go
@@ -19,7 +19,7 @@ type decoder struct {
 func Decode(data []byte, v interface{}, asArray bool) error {
 	d := decoder{data: data, asArray: asArray}
 
-	if d.data == nil || len(d.data) < 1 {
+	if len(d.data) < 1 {
 		return def.ErrNoData
 	}
 	rv := reflect.ValueOf(v)

--- a/internal/decoding/ext.go
+++ b/internal/decoding/ext.go
@@ -1,6 +1,9 @@
 package decoding
 
 import (
+	"encoding/binary"
+
+	"github.com/shamaton/msgpack/v2/def"
 	"github.com/shamaton/msgpack/v2/ext"
 	"github.com/shamaton/msgpack/v2/time"
 )
@@ -42,6 +45,57 @@ func updateExtCoders() {
 	for k := range extCoderMap {
 		extCoders[i] = extCoderMap[k]
 		i++
+	}
+}
+
+func (d *decoder) extEndOffset(offset int) (bool, int, error) {
+	code, offset, err := d.readSize1(offset)
+	if err != nil {
+		return false, 0, err
+	}
+	return d.extEndOffsetWithCode(code, offset)
+}
+
+func (d *decoder) extEndOffsetWithCode(code byte, offset int) (bool, int, error) {
+	switch code {
+	case def.Fixext1:
+		_, offset, err := d.readSizeN(offset, def.Byte1+def.Byte1)
+		return true, offset, err
+	case def.Fixext2:
+		_, offset, err := d.readSizeN(offset, def.Byte1+def.Byte2)
+		return true, offset, err
+	case def.Fixext4:
+		_, offset, err := d.readSizeN(offset, def.Byte1+def.Byte4)
+		return true, offset, err
+	case def.Fixext8:
+		_, offset, err := d.readSizeN(offset, def.Byte1+def.Byte8)
+		return true, offset, err
+	case def.Fixext16:
+		_, offset, err := d.readSizeN(offset, def.Byte1+def.Byte16)
+		return true, offset, err
+	case def.Ext8:
+		size, offset, err := d.readSize1(offset)
+		if err != nil {
+			return true, 0, err
+		}
+		_, offset, err = d.readSizeN(offset, def.Byte1+int(size))
+		return true, offset, err
+	case def.Ext16:
+		sizeBytes, offset, err := d.readSize2(offset)
+		if err != nil {
+			return true, 0, err
+		}
+		_, offset, err = d.readSizeN(offset, def.Byte1+int(binary.BigEndian.Uint16(sizeBytes)))
+		return true, offset, err
+	case def.Ext32:
+		sizeBytes, offset, err := d.readSize4(offset)
+		if err != nil {
+			return true, 0, err
+		}
+		_, offset, err = d.readSizeN(offset, def.Byte1+int(binary.BigEndian.Uint32(sizeBytes)))
+		return true, offset, err
+	default:
+		return false, 0, nil
 	}
 }
 

--- a/internal/decoding/ext_test.go
+++ b/internal/decoding/ext_test.go
@@ -1,8 +1,10 @@
 package decoding
 
 import (
+	"reflect"
 	"testing"
 
+	"github.com/shamaton/msgpack/v2/def"
 	tu "github.com/shamaton/msgpack/v2/internal/common/testutil"
 	"github.com/shamaton/msgpack/v2/time"
 )
@@ -19,4 +21,68 @@ func Test_RemoveExtDecoder(t *testing.T) {
 		RemoveExtDecoder(time.Decoder)
 		tu.Equal(t, len(extCoders), 1)
 	})
+}
+
+type trackingExtDecoder struct {
+	isTypeCalls  int
+	asValueCalls int
+}
+
+func (td *trackingExtDecoder) Code() int8 {
+	return 42
+}
+
+func (td *trackingExtDecoder) IsType(_ int, _ *[]byte) bool {
+	td.isTypeCalls++
+	return false
+}
+
+func (td *trackingExtDecoder) AsValue(_ int, _ reflect.Kind, _ *[]byte) (interface{}, int, error) {
+	td.asValueCalls++
+	return nil, 0, ErrTestExtDecoder
+}
+
+func TestExtValidationRejectsTruncatedBytesBeforeCustomDecoders(t *testing.T) {
+	dec := &trackingExtDecoder{}
+	AddExtDecoder(dec)
+	defer RemoveExtDecoder(dec)
+
+	testcases := []struct {
+		name string
+		data []byte
+	}{
+		{name: "fixext1", data: []byte{def.Fixext1, 42}},
+		{name: "fixext2", data: []byte{def.Fixext2, 42, 0}},
+		{name: "fixext4", data: []byte{def.Fixext4, 42, 0, 0, 0}},
+		{name: "fixext8", data: []byte{def.Fixext8, 42, 0, 0, 0, 0, 0, 0, 0}},
+		{name: "fixext16", data: []byte{def.Fixext16, 42, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0}},
+		{name: "ext8", data: []byte{def.Ext8, 1, 42}},
+		{name: "ext16", data: []byte{def.Ext16, 0, 1, 42}},
+		{name: "ext32", data: []byte{def.Ext32, 0, 0, 0, 1, 42}},
+	}
+
+	for _, tc := range testcases {
+		t.Run("interface/"+tc.name, func(t *testing.T) {
+			dec.isTypeCalls = 0
+			dec.asValueCalls = 0
+
+			d := decoder{data: tc.data}
+			_, _, err := d.asInterface(0, reflect.Interface)
+			tu.IsError(t, err, def.ErrTooShortBytes)
+			tu.Equal(t, dec.isTypeCalls, 0)
+			tu.Equal(t, dec.asValueCalls, 0)
+		})
+
+		t.Run("struct/"+tc.name, func(t *testing.T) {
+			dec.isTypeCalls = 0
+			dec.asValueCalls = 0
+
+			d := decoder{data: tc.data}
+			var v struct{}
+			_, err := d.setStruct(reflect.ValueOf(&v).Elem(), 0, reflect.Struct)
+			tu.IsError(t, err, def.ErrTooShortBytes)
+			tu.Equal(t, dec.isTypeCalls, 0)
+			tu.Equal(t, dec.asValueCalls, 0)
+		})
+	}
 }

--- a/internal/decoding/interface.go
+++ b/internal/decoding/interface.go
@@ -163,13 +163,19 @@ func (d *decoder) asInterface(offset int, k reflect.Kind) (interface{}, int, err
 	*/
 
 	// ext
-	for i := range extCoders {
-		if extCoders[i].IsType(offset, &d.data) {
-			v, offset, err := extCoders[i].AsValue(offset, k, &d.data)
-			if err != nil {
-				return nil, 0, err
+	isExt, _, err := d.extEndOffset(offset)
+	if err != nil {
+		return nil, 0, err
+	}
+	if isExt {
+		for i := range extCoders {
+			if extCoders[i].IsType(offset, &d.data) {
+				v, offset, err := extCoders[i].AsValue(offset, k, &d.data)
+				if err != nil {
+					return nil, 0, err
+				}
+				return v, offset, nil
 			}
-			return v, offset, nil
 		}
 	}
 	return nil, 0, d.errorTemplate(code, k)

--- a/internal/decoding/interface_test.go
+++ b/internal/decoding/interface_test.go
@@ -151,8 +151,14 @@ func Test_asInterfaceWithCode(t *testing.T) {
 			MethodAs: method,
 		},
 		{
-			Name:     "ExtCoder.error",
+			Name:     "ExtCoder.error.truncated",
 			Data:     []byte{def.Fixext1, 3},
+			Error:    def.ErrTooShortBytes,
+			MethodAs: method,
+		},
+		{
+			Name:     "ExtCoder.error",
+			Data:     []byte{def.Fixext1, 3, 0},
 			Error:    ErrTestExtDecoder,
 			MethodAs: method,
 		},

--- a/internal/decoding/struct.go
+++ b/internal/decoding/struct.go
@@ -33,17 +33,23 @@ func (d *decoder) setStruct(rv reflect.Value, offset int, k reflect.Kind) (int, 
 		}
 	*/
 
-	for i := range extCoders {
-		if extCoders[i].IsType(offset, &d.data) {
-			v, offset, err := extCoders[i].AsValue(offset, k, &d.data)
-			if err != nil {
-				return 0, err
-			}
+	isExt, _, err := d.extEndOffset(offset)
+	if err != nil {
+		return 0, err
+	}
+	if isExt {
+		for i := range extCoders {
+			if extCoders[i].IsType(offset, &d.data) {
+				v, offset, err := extCoders[i].AsValue(offset, k, &d.data)
+				if err != nil {
+					return 0, err
+				}
 
-			// Validate that the receptacle is of the right value type.
-			if rv.Type() == reflect.TypeOf(v) {
-				rv.Set(reflect.ValueOf(v))
-				return offset, nil
+				// Validate that the receptacle is of the right value type.
+				if rv.Type() == reflect.TypeOf(v) {
+					rv.Set(reflect.ValueOf(v))
+					return offset, nil
+				}
 			}
 		}
 	}
@@ -277,38 +283,14 @@ func (d *decoder) jumpOffset(offset int) (int, error) {
 		}
 		offset = o
 
-	case code == def.Fixext1:
-		offset += def.Byte1 + def.Byte1
-	case code == def.Fixext2:
-		offset += def.Byte1 + def.Byte2
-	case code == def.Fixext4:
-		offset += def.Byte1 + def.Byte4
-	case code == def.Fixext8:
-		offset += def.Byte1 + def.Byte8
-	case code == def.Fixext16:
-		offset += def.Byte1 + def.Byte16
-
-	case code == def.Ext8:
-		b, o, err := d.readSize1(offset)
+	default:
+		isExt, o, err := d.extEndOffsetWithCode(code, offset)
 		if err != nil {
 			return 0, err
 		}
-		o += def.Byte1 + int(b)
-		offset = o
-	case code == def.Ext16:
-		bs, o, err := d.readSize2(offset)
-		if err != nil {
-			return 0, err
+		if isExt {
+			offset = o
 		}
-		o += def.Byte1 + int(binary.BigEndian.Uint16(bs))
-		offset = o
-	case code == def.Ext32:
-		bs, o, err := d.readSize4(offset)
-		if err != nil {
-			return 0, err
-		}
-		o += def.Byte1 + int(binary.BigEndian.Uint32(bs))
-		offset = o
 
 	}
 	return offset, nil

--- a/internal/decoding/struct_test.go
+++ b/internal/decoding/struct_test.go
@@ -399,8 +399,20 @@ func Test_jumpOffset(t *testing.T) {
 			MethodAs: method,
 		},
 		{
+			Name:     "Fixext1.ng",
+			Data:     []byte{def.Fixext1},
+			Error:    def.ErrTooShortBytes,
+			MethodAs: method,
+		},
+		{
 			Name:     "Fixext1.ok",
 			Data:     []byte{def.Fixext1, 0, 0},
+			MethodAs: method,
+		},
+		{
+			Name:     "Fixext2.ng",
+			Data:     []byte{def.Fixext2},
+			Error:    def.ErrTooShortBytes,
 			MethodAs: method,
 		},
 		{
@@ -409,13 +421,31 @@ func Test_jumpOffset(t *testing.T) {
 			MethodAs: method,
 		},
 		{
+			Name:     "Fixext4.ng",
+			Data:     []byte{def.Fixext4},
+			Error:    def.ErrTooShortBytes,
+			MethodAs: method,
+		},
+		{
 			Name:     "Fixext4.ok",
 			Data:     []byte{def.Fixext4, 0, 0, 0, 0, 0},
 			MethodAs: method,
 		},
 		{
+			Name:     "Fixext8.ng",
+			Data:     []byte{def.Fixext8},
+			Error:    def.ErrTooShortBytes,
+			MethodAs: method,
+		},
+		{
 			Name:     "Fixext8.ok",
 			Data:     []byte{def.Fixext8, 0, 0, 0, 0, 0, 0, 0, 0, 0},
+			MethodAs: method,
+		},
+		{
+			Name:     "Fixext16.ng",
+			Data:     []byte{def.Fixext16},
+			Error:    def.ErrTooShortBytes,
 			MethodAs: method,
 		},
 		{

--- a/msgpack_test.go
+++ b/msgpack_test.go
@@ -572,7 +572,7 @@ func TestAny(t *testing.T) {
 	t.Run("AnyError", func(t *testing.T) {
 		var r any
 		err := msgpack.Unmarshal([]byte{def.Ext32}, &r)
-		ErrorContains(t, err, "invalid code")
+		ErrorContains(t, err, "too short bytes")
 	})
 }
 

--- a/time/decode.go
+++ b/time/decode.go
@@ -24,30 +24,86 @@ func (td *timeDecoder) Code() int8 {
 	return def.TimeStamp
 }
 
-func (td *timeDecoder) IsType(offset int, d *[]byte) bool {
-	code, offset := td.ReadSize1(offset, d)
+func (td *timeDecoder) readSize1Safe(index int, d *[]byte) (byte, int, bool) {
+	if len(*d) < index+def.Byte1 {
+		return 0, 0, false
+	}
+	v, next := td.ReadSize1(index, d)
+	return v, next, true
+}
 
-	if code == def.Fixext4 {
-		t, _ := td.ReadSize1(offset, d)
-		return int8(t) == td.Code()
-	} else if code == def.Fixext8 {
-		t, _ := td.ReadSize1(offset, d)
-		return int8(t) == td.Code()
-	} else if code == def.Ext8 {
-		l, offset := td.ReadSize1(offset, d)
-		t, _ := td.ReadSize1(offset, d)
-		return l == 12 && int8(t) == td.Code()
+func (td *timeDecoder) readSize4Safe(index int, d *[]byte) ([]byte, int, bool) {
+	if len(*d) < index+def.Byte4 {
+		return nil, 0, false
+	}
+	v, next := td.ReadSize4(index, d)
+	return v, next, true
+}
+
+func (td *timeDecoder) readSize8Safe(index int, d *[]byte) ([]byte, int, bool) {
+	if len(*d) < index+def.Byte8 {
+		return nil, 0, false
+	}
+	v, next := td.ReadSize8(index, d)
+	return v, next, true
+}
+
+func (td *timeDecoder) IsType(offset int, d *[]byte) bool {
+	code, offset, ok := td.readSize1Safe(offset, d)
+	if !ok {
+		return false
+	}
+
+	switch code {
+	case def.Fixext4:
+		t, _, ok := td.readSize1Safe(offset, d)
+		if !ok || int8(t) != td.Code() {
+			return false
+		}
+		_, _, ok = td.readSize4Safe(offset+def.Byte1, d)
+		return ok
+	case def.Fixext8:
+		t, _, ok := td.readSize1Safe(offset, d)
+		if !ok || int8(t) != td.Code() {
+			return false
+		}
+		_, _, ok = td.readSize8Safe(offset+def.Byte1, d)
+		return ok
+	case def.Ext8:
+		l, offset, ok := td.readSize1Safe(offset, d)
+		if !ok {
+			return false
+		}
+		t, _, ok := td.readSize1Safe(offset, d)
+		if !ok || l != 12 || int8(t) != td.Code() {
+			return false
+		}
+		_, _, ok = td.readSize4Safe(offset+def.Byte1, d)
+		if !ok {
+			return false
+		}
+		_, _, ok = td.readSize8Safe(offset+def.Byte1+def.Byte4, d)
+		return ok
 	}
 	return false
 }
 
 func (td *timeDecoder) AsValue(offset int, k reflect.Kind, d *[]byte) (interface{}, int, error) {
-	code, offset := td.ReadSize1(offset, d)
+	code, offset, ok := td.readSize1Safe(offset, d)
+	if !ok {
+		return zero, 0, def.ErrTooShortBytes
+	}
 
 	switch code {
 	case def.Fixext4:
-		_, offset = td.ReadSize1(offset, d)
-		bs, offset := td.ReadSize4(offset, d)
+		_, offset, ok = td.readSize1Safe(offset, d)
+		if !ok {
+			return zero, 0, def.ErrTooShortBytes
+		}
+		bs, offset, ok := td.readSize4Safe(offset, d)
+		if !ok {
+			return zero, 0, def.ErrTooShortBytes
+		}
 		v := time.Unix(int64(binary.BigEndian.Uint32(bs)), 0)
 		if decodeAsLocal {
 			return v, offset, nil
@@ -55,8 +111,14 @@ func (td *timeDecoder) AsValue(offset int, k reflect.Kind, d *[]byte) (interface
 		return v.UTC(), offset, nil
 
 	case def.Fixext8:
-		_, offset = td.ReadSize1(offset, d)
-		bs, offset := td.ReadSize8(offset, d)
+		_, offset, ok = td.readSize1Safe(offset, d)
+		if !ok {
+			return zero, 0, def.ErrTooShortBytes
+		}
+		bs, offset, ok := td.readSize8Safe(offset, d)
+		if !ok {
+			return zero, 0, def.ErrTooShortBytes
+		}
 		data64 := binary.BigEndian.Uint64(bs)
 		nano := int64(data64 >> 34)
 		if nano > 999999999 {
@@ -69,10 +131,22 @@ func (td *timeDecoder) AsValue(offset int, k reflect.Kind, d *[]byte) (interface
 		return v.UTC(), offset, nil
 
 	case def.Ext8:
-		_, offset = td.ReadSize1(offset, d)
-		_, offset = td.ReadSize1(offset, d)
-		nanobs, offset := td.ReadSize4(offset, d)
-		secbs, offset := td.ReadSize8(offset, d)
+		_, offset, ok = td.readSize1Safe(offset, d)
+		if !ok {
+			return zero, 0, def.ErrTooShortBytes
+		}
+		_, offset, ok = td.readSize1Safe(offset, d)
+		if !ok {
+			return zero, 0, def.ErrTooShortBytes
+		}
+		nanobs, offset, ok := td.readSize4Safe(offset, d)
+		if !ok {
+			return zero, 0, def.ErrTooShortBytes
+		}
+		secbs, offset, ok := td.readSize8Safe(offset, d)
+		if !ok {
+			return zero, 0, def.ErrTooShortBytes
+		}
 		nano := binary.BigEndian.Uint32(nanobs)
 		if nano > 999999999 {
 			return zero, 0, fmt.Errorf("in timestamp 96 formats, nanoseconds must not be larger than 999999999 : %d", nano)

--- a/time/decode_stream.go
+++ b/time/decode_stream.go
@@ -33,6 +33,9 @@ func (td *timeStreamDecoder) IsType(code byte, innerType int8, dataLength int) b
 func (td *timeStreamDecoder) ToValue(code byte, data []byte, k reflect.Kind) (interface{}, error) {
 	switch code {
 	case def.Fixext4:
+		if len(data) < def.Byte4 {
+			return zero, def.ErrTooShortBytes
+		}
 		v := time.Unix(int64(binary.BigEndian.Uint32(data)), 0)
 		if decodeAsLocal {
 			return v, nil
@@ -40,6 +43,9 @@ func (td *timeStreamDecoder) ToValue(code byte, data []byte, k reflect.Kind) (in
 		return v.UTC(), nil
 
 	case def.Fixext8:
+		if len(data) < def.Byte8 {
+			return zero, def.ErrTooShortBytes
+		}
 		data64 := binary.BigEndian.Uint64(data)
 		nano := int64(data64 >> 34)
 		if nano > 999999999 {
@@ -52,6 +58,9 @@ func (td *timeStreamDecoder) ToValue(code byte, data []byte, k reflect.Kind) (in
 		return v.UTC(), nil
 
 	case def.Ext8:
+		if len(data) < def.Byte4+def.Byte8 {
+			return zero, def.ErrTooShortBytes
+		}
 		nano := binary.BigEndian.Uint32(data[:4])
 		if nano > 999999999 {
 			return zero, fmt.Errorf("in timestamp 96 formats, nanoseconds must not be larger than 999999999 : %d", nano)

--- a/time/decode_stream_test.go
+++ b/time/decode_stream_test.go
@@ -257,6 +257,27 @@ func TestStreamDecodeToValueErrors(t *testing.T) {
 	})
 }
 
+func TestStreamDecodeToValueTooShort(t *testing.T) {
+	decoder := StreamDecoder
+
+	testcases := []struct {
+		name string
+		code byte
+		data []byte
+	}{
+		{name: "Fixext4", code: def.Fixext4, data: []byte{}},
+		{name: "Fixext8", code: def.Fixext8, data: []byte{}},
+		{name: "Ext8", code: def.Ext8, data: []byte{}},
+	}
+
+	for _, tc := range testcases {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := decoder.ToValue(tc.code, tc.data, reflect.TypeOf(time.Time{}).Kind())
+			tu.IsError(t, err, def.ErrTooShortBytes)
+		})
+	}
+}
+
 func TestStreamDecodeTimezone(t *testing.T) {
 	decoder := StreamDecoder
 

--- a/time/decode_test.go
+++ b/time/decode_test.go
@@ -75,6 +75,30 @@ func TestDecodeIsType(t *testing.T) {
 	}
 }
 
+func TestDecodeIsTypeShortInput(t *testing.T) {
+	decoder := Decoder
+	ts := def.TimeStamp
+
+	testcases := []struct {
+		name string
+		data []byte
+	}{
+		{name: "Fixext4 missing type", data: []byte{def.Fixext4}},
+		{name: "Fixext8 missing type", data: []byte{def.Fixext8}},
+		{name: "Ext8 missing length", data: []byte{def.Ext8}},
+		{name: "Ext8 missing type", data: []byte{def.Ext8, 12}},
+		{name: "Fixext4 missing payload", data: []byte{def.Fixext4, byte(ts)}},
+		{name: "Fixext8 missing payload", data: []byte{def.Fixext8, byte(ts)}},
+		{name: "Ext8 missing payload", data: []byte{def.Ext8, 12, byte(ts)}},
+	}
+
+	for _, tc := range testcases {
+		t.Run(tc.name, func(t *testing.T) {
+			tu.Equal(t, decoder.IsType(0, &tc.data), false)
+		})
+	}
+}
+
 func TestDecodeAsValueFixext4(t *testing.T) {
 	decoder := Decoder
 	ts := def.TimeStamp
@@ -256,6 +280,31 @@ func TestDecodeAsValueErrors(t *testing.T) {
 		_, _, err := decoder.AsValue(0, reflect.TypeOf(time.Time{}).Kind(), &data)
 		tu.ErrorContains(t, err, "should not reach")
 	})
+}
+
+func TestDecodeAsValueTooShort(t *testing.T) {
+	decoder := Decoder
+	ts := def.TimeStamp
+
+	testcases := []struct {
+		name string
+		data []byte
+	}{
+		{name: "Fixext4 missing type", data: []byte{def.Fixext4}},
+		{name: "Fixext4 missing payload", data: []byte{def.Fixext4, byte(ts)}},
+		{name: "Fixext8 missing type", data: []byte{def.Fixext8}},
+		{name: "Fixext8 missing payload", data: []byte{def.Fixext8, byte(ts)}},
+		{name: "Ext8 missing length", data: []byte{def.Ext8}},
+		{name: "Ext8 missing type", data: []byte{def.Ext8, 12}},
+		{name: "Ext8 missing payload", data: []byte{def.Ext8, 12, byte(ts)}},
+	}
+
+	for _, tc := range testcases {
+		t.Run(tc.name, func(t *testing.T) {
+			_, _, err := decoder.AsValue(0, reflect.TypeOf(time.Time{}).Kind(), &tc.data)
+			tu.IsError(t, err, def.ErrTooShortBytes)
+		})
+	}
 }
 
 func TestDecodeTimezone(t *testing.T) {

--- a/unmarshal_ext_test.go
+++ b/unmarshal_ext_test.go
@@ -1,0 +1,42 @@
+package msgpack_test
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/shamaton/msgpack/v2"
+	"github.com/shamaton/msgpack/v2/def"
+)
+
+func TestUnmarshalTruncatedTimestampExtReturnsTooShort(t *testing.T) {
+	ts := def.TimeStamp
+
+	testcases := []struct {
+		name string
+		data []byte
+	}{
+		{name: "fixext4", data: []byte{def.Fixext4, byte(ts)}},
+		{name: "fixext8", data: []byte{def.Fixext8, byte(ts)}},
+	}
+
+	methods := []struct {
+		name string
+		fn   func([]byte, interface{}) error
+	}{
+		{name: "Unmarshal", fn: msgpack.Unmarshal},
+		{name: "UnmarshalAsArray", fn: msgpack.UnmarshalAsArray},
+		{name: "UnmarshalAsMap", fn: msgpack.UnmarshalAsMap},
+	}
+
+	for _, method := range methods {
+		for _, tc := range testcases {
+			t.Run(method.name+"/"+tc.name, func(t *testing.T) {
+				var v interface{}
+				err := method.fn(tc.data, &v)
+				if !errors.Is(err, def.ErrTooShortBytes) {
+					t.Fatalf("expected %v, got %v", def.ErrTooShortBytes, err)
+				}
+			})
+		}
+	}
+}


### PR DESCRIPTION
## Summary

- Backport `269f54e` from `v3.1.1` to `v2`
- Validate ext frame bounds before invoking custom ext decoders
- Add regression tests for truncated ext/timestamp payloads

## Verification

- `go test ./...`

## Issue/PR

- #59 
- #60 
