### PR TITLE
Add tagpr configuration for v2

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,4 @@
+changelog:
+  exclude:
+    labels:
+      - tagpr

--- a/.github/workflows/tagpr.yml
+++ b/.github/workflows/tagpr.yml
@@ -1,0 +1,20 @@
+name: tagpr
+
+on:
+  push:
+    branches: ["v2"]
+
+jobs:
+  tagpr:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+      issues: read
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+      - uses: Songmu/tagpr@555e72cee68c09d43dc2337dc9ba890955b630da # v1.19.0
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.tagpr
+++ b/.tagpr
@@ -1,0 +1,7 @@
+[tagpr]
+    releaseBranch = v2
+    versionFile = -
+    vPrefix = true
+    changelog = true
+    release = true
+    fixedMajorVersion = 2


### PR DESCRIPTION
## Summary
- Add tagpr workflow to automate release PR and tag creation for `v2`.
- Configure tagpr for `v2`, changelog generation, and v-prefixed tags.
- Exclude tagpr-labeled PRs from GitHub release changelogs.

## Background / Motivation
Automates the release flow with tagpr so release PRs, changelogs, and tags can be managed consistently from the `v2` branch.

## Changes
- Add `.github/workflows/tagpr.yml` GitHub Actions workflow.
- Add `.tagpr` configuration with fixed major version `2`.
- Add `.github/release.yml` changelog exclusion for the `tagpr` label.

## Test Plan
- `pinact run --check --verify .github/workflows/tagpr.yml`
- `go test ./...`

## Notes
- The tagpr workflow runs on pushes to `v2`.
- `CHANGELOG.md` will be created separately for v2.