### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,6 +2,9 @@ name: test
 
 on: [push, pull_request]
 
+permissions:
+  contents: read
+
 env:
   GOPATH: ${{ github.workspace }}
   WORKSPACE: ${{ github.workspace }}/src/github.com/${{ github.repository }}
@@ -58,6 +61,9 @@ jobs:
 
   lint:
     needs: test
+    permissions:
+      contents: read
+      pull-requests: write
     runs-on: ubuntu-latest
     steps:
       - name: Checkout


### PR DESCRIPTION
Potential fix for [https://github.com/shamaton/msgpack/security/code-scanning/1](https://github.com/shamaton/msgpack/security/code-scanning/1)

Add explicit `permissions` in `.github/workflows/test.yml`:

1. **Workflow-level default**: set `permissions: { contents: read }` near the top (after `on`), so all jobs get least-privilege read access by default.
2. **Job-level override for `lint`**: add `permissions` under `jobs.lint` with:
   - `contents: read`
   - `pull-requests: write` (needed for `reviewdog` with `reporter: github-pr-review` to post PR review comments)

This keeps existing behavior while constraining token access. No imports, methods, or external definitions are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
