### PR TITLE
fix: honor registered ext coders for named non-struct types across encode/decode and stream APIs (#55)

### DIFF
--- a/internal/decoding/benchmark_test.go
+++ b/internal/decoding/benchmark_test.go
@@ -1,0 +1,128 @@
+package decoding
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/shamaton/msgpack/v3/def"
+	"github.com/shamaton/msgpack/v3/ext"
+	"github.com/shamaton/msgpack/v3/internal/encoding"
+)
+
+// benchStatus is a named non-struct type, as commonly used for "enums" in Go.
+type benchStatus int
+
+type benchStatusEncoder struct {
+	ext.EncoderCommon
+}
+
+func (e *benchStatusEncoder) Code() int8         { return 44 }
+func (e *benchStatusEncoder) Type() reflect.Type { return reflect.TypeOf(benchStatus(0)) }
+func (e *benchStatusEncoder) CalcByteSize(reflect.Value) (int, error) {
+	return def.Byte1 + def.Byte1 + def.Byte1, nil
+}
+func (e *benchStatusEncoder) WriteToBytes(value reflect.Value, offset int, data *[]byte) int {
+	offset = e.SetByte1Int(def.Fixext1, offset, data)
+	offset = e.SetByte1Int(int(e.Code()), offset, data)
+	return e.SetByte1Int64(value.Int(), offset, data)
+}
+
+type benchStatusDecoder struct{}
+
+func (*benchStatusDecoder) Code() int8 { return 44 }
+func (*benchStatusDecoder) IsType(offset int, data *[]byte) bool {
+	return (*data)[offset] == def.Fixext1 && int8((*data)[offset+1]) == 44
+}
+func (*benchStatusDecoder) AsValue(offset int, _ reflect.Kind, data *[]byte) (interface{}, int, error) {
+	return benchStatus(int8((*data)[offset+2])), offset + 3, nil
+}
+
+func makeBenchStatusSlice() []benchStatus {
+	values := make([]benchStatus, 1024)
+	for i := range values {
+		values[i] = benchStatus(i % 128)
+	}
+	return values
+}
+
+func benchmarkDecode(b *testing.B, encoded []byte, target func() any) {
+	b.Helper()
+	b.ReportAllocs()
+	b.ResetTimer()
+	for b.Loop() {
+		v := target()
+		if err := Decode(encoded, v, false); err != nil {
+			b.Fatal(err)
+		}
+	}
+	b.StopTimer()
+}
+
+// BenchmarkDecodeInt measures the common non-ext path: it must not regress
+// once ext dispatch is consulted generically in decode(), not just setStruct.
+func BenchmarkDecodeInt(b *testing.B) {
+	encoded, err := encoding.Encode(int(42), false)
+	if err != nil {
+		b.Fatal(err)
+	}
+	benchmarkDecode(b, encoded, func() any { var v int; return &v })
+}
+
+func BenchmarkDecodeIntSlice(b *testing.B) {
+	values := make([]int, 1024)
+	for i := range values {
+		values[i] = i % 128
+	}
+	encoded, err := encoding.Encode(values, false)
+	if err != nil {
+		b.Fatal(err)
+	}
+	benchmarkDecode(b, encoded, func() any { var v []int; return &v })
+}
+
+type benchStruct struct {
+	ID     int64
+	Name   string
+	Active bool
+	Score  float64
+	Tags   []string
+}
+
+func BenchmarkDecodeStruct(b *testing.B) {
+	value := benchStruct{ID: 42, Name: "benchmark", Active: true, Score: 12.5, Tags: []string{"a", "b", "c", "d"}}
+	encoded, err := encoding.Encode(value, false)
+	if err != nil {
+		b.Fatal(err)
+	}
+	benchmarkDecode(b, encoded, func() any { var v benchStruct; return &v })
+}
+
+func BenchmarkDecodeStatus(b *testing.B) {
+	encoder := &benchStatusEncoder{}
+	decoder := &benchStatusDecoder{}
+	encoding.AddExtEncoder(encoder)
+	defer encoding.RemoveExtEncoder(encoder)
+	AddExtDecoder(decoder)
+	defer RemoveExtDecoder(decoder)
+
+	encoded, err := encoding.Encode(benchStatus(42), false)
+	if err != nil {
+		b.Fatal(err)
+	}
+	benchmarkDecode(b, encoded, func() any { var v benchStatus; return &v })
+}
+
+func BenchmarkDecodeStatusSlice(b *testing.B) {
+	encoder := &benchStatusEncoder{}
+	decoder := &benchStatusDecoder{}
+	encoding.AddExtEncoder(encoder)
+	defer encoding.RemoveExtEncoder(encoder)
+	AddExtDecoder(decoder)
+	defer RemoveExtDecoder(decoder)
+
+	encoded, err := encoding.Encode(makeBenchStatusSlice(), false)
+	if err != nil {
+		b.Fatal(err)
+	}
+	benchmarkDecode(b, encoded, func() any { var v []benchStatus; return &v })
+}

--- a/internal/decoding/decoding.go
+++ b/internal/decoding/decoding.go
@@ -42,6 +42,16 @@ func Decode(data []byte, v interface{}, asArray bool) error {
 
 func (d *decoder) decode(rv reflect.Value, offset int) (int, error) {
 	k := rv.Kind()
+
+	// ext types: honor a registered ext decoder for any destination kind, not
+	// just structs (mirrors setStruct). Falls through to the kind switch when
+	// nothing matches, e.g. because no ext coder claims the bytes.
+	if o, ok, err := d.tryExtDecode(rv, offset, k); err != nil {
+		return 0, err
+	} else if ok {
+		return o, nil
+	}
+
 	switch k {
 	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
 		v, o, err := d.asInt(offset, k)

--- a/internal/decoding/defined_type_ext_test.go
+++ b/internal/decoding/defined_type_ext_test.go
@@ -1,0 +1,102 @@
+package decoding
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/shamaton/msgpack/v3/def"
+	"github.com/shamaton/msgpack/v3/ext"
+	tu "github.com/shamaton/msgpack/v3/internal/common/testutil"
+)
+
+// issue55Status/issue55Statuses mirror the encode-side fixtures in
+// defined_type_ext_test.go: named non-struct types, as commonly used for Go
+// "enums", that must round-trip through a registered ext decoder.
+type issue55DecStatus int
+type issue55DecStatuses []issue55DecStatus
+
+type issue55DecHolder struct {
+	Status issue55DecStatus
+}
+
+// issue55DecDecoder decodes a fixext1 frame whose payload byte is the raw
+// int value of issue55DecStatus.
+type issue55DecDecoder struct {
+	code       int8
+	isTypeHits int
+}
+
+func (d *issue55DecDecoder) Code() int8 { return d.code }
+
+func (d *issue55DecDecoder) IsType(offset int, data *[]byte) bool {
+	d.isTypeHits++
+	if (*data)[offset] != def.Fixext1 {
+		return false
+	}
+	return int8((*data)[offset+1]) == d.code
+}
+
+func (d *issue55DecDecoder) AsValue(offset int, _ reflect.Kind, data *[]byte) (interface{}, int, error) {
+	return issue55DecStatus((*data)[offset+2]), offset + 3, nil
+}
+
+func issue55DecBytes(code int8, v issue55DecStatus) []byte {
+	return []byte{def.Fixext1, byte(code), byte(v)}
+}
+
+func Test_DecodeExtCoderForNamedNonStructType(t *testing.T) {
+	dec := &issue55DecDecoder{code: 41}
+	AddExtDecoder(dec)
+	defer RemoveExtDecoder(dec)
+
+	t.Run("top level", func(t *testing.T) {
+		var got issue55DecStatus
+		d := decoder{data: issue55DecBytes(41, 7)}
+		_, err := d.decode(reflect.ValueOf(&got).Elem(), 0)
+		tu.NoError(t, err)
+		tu.Equal(t, got, issue55DecStatus(7))
+	})
+
+	t.Run("slice element", func(t *testing.T) {
+		data := append([]byte{def.FixArray + 2}, issue55DecBytes(41, 1)...)
+		data = append(data, issue55DecBytes(41, 2)...)
+
+		var got []issue55DecStatus
+		d := decoder{data: data}
+		_, err := d.decode(reflect.ValueOf(&got).Elem(), 0)
+		tu.NoError(t, err)
+		tu.EqualSlice(t, []byte(convertToBytes(got)), []byte(convertToBytes(issue55DecStatuses{1, 2})))
+	})
+
+	t.Run("struct field via map", func(t *testing.T) {
+		data := append([]byte{def.FixMap + 1, def.FixStr + byte(len("Status"))}, "Status"...)
+		data = append(data, issue55DecBytes(41, 9)...)
+
+		var got issue55DecHolder
+		d := decoder{data: data, asArray: false}
+		_, err := d.decode(reflect.ValueOf(&got).Elem(), 0)
+		tu.NoError(t, err)
+		tu.Equal(t, got.Status, issue55DecStatus(9))
+	})
+
+	t.Run("no match falls back to kind switch", func(t *testing.T) {
+		// A registered decoder whose IsType never matches must not prevent an
+		// ordinary (non-ext) value of the same underlying kind from decoding.
+		var got issue55DecStatus
+		d := decoder{data: []byte{0x05}} // fixint 5, not an ext frame
+		_, err := d.decode(reflect.ValueOf(&got).Elem(), 0)
+		tu.NoError(t, err)
+		tu.Equal(t, got, issue55DecStatus(5))
+	})
+}
+
+func convertToBytes(v any) []byte {
+	rv := reflect.ValueOf(v)
+	bs := make([]byte, rv.Len())
+	for i := 0; i < rv.Len(); i++ {
+		bs[i] = byte(rv.Index(i).Int())
+	}
+	return bs
+}
+
+var _ = ext.Decoder((*issue55DecDecoder)(nil))

--- a/internal/decoding/ext.go
+++ b/internal/decoding/ext.go
@@ -2,6 +2,7 @@ package decoding
 
 import (
 	"encoding/binary"
+	"reflect"
 
 	"github.com/shamaton/msgpack/v3/def"
 	"github.com/shamaton/msgpack/v3/ext"
@@ -48,6 +49,51 @@ func updateExtCoders() {
 		extCoders[i] = extCoderMap[k]
 		i++
 	}
+}
+
+// tryExtDecode attempts to decode the value at offset using a registered ext
+// decoder whose Go type matches the destination rv, mirroring the dispatch
+// setStruct already performed for struct destinations only. extEndOffset both
+// recognizes the ext wire codes and validates that the full ext frame (header
+// and payload) is present, so truncated input is rejected with
+// def.ErrTooShortBytes before any custom decoder callback runs; non-ext bytes
+// fall out of extEndOffset's switch immediately, so this costs a single
+// bounds-checked byte read for the common non-ext case. Returns ok=false
+// (with offset==0) when no registered decoder claims the bytes, so callers
+// fall back to the normal kind-based decoding (which will surface a clear
+// type-mismatch error).
+func (d *decoder) tryExtDecode(rv reflect.Value, offset int, k reflect.Kind) (int, bool, error) {
+	if len(extCoders) == 0 {
+		return 0, false, nil
+	}
+	// The only registered decoder is the built-in time.Decoder, which targets
+	// a struct destination; skip the check entirely for other kinds. Use
+	// rv.Kind() rather than the passed-in k: callers such as the slice-of-
+	// struct fast path pass the container's kind, not the element's.
+	if len(extCoders) == 1 && rv.Kind() != reflect.Struct {
+		return 0, false, nil
+	}
+	isExt, _, err := d.extEndOffset(offset)
+	if err != nil {
+		return 0, false, err
+	}
+	if !isExt {
+		return 0, false, nil
+	}
+	for i := range extCoders {
+		if !extCoders[i].IsType(offset, &d.data) {
+			continue
+		}
+		v, o, err := extCoders[i].AsValue(offset, k, &d.data)
+		if err != nil {
+			return 0, false, err
+		}
+		if rv.Type() == reflect.TypeOf(v) {
+			rv.Set(reflect.ValueOf(v))
+			return o, true, nil
+		}
+	}
+	return 0, false, nil
 }
 
 func (d *decoder) extEndOffset(offset int) (bool, int, error) {

--- a/internal/decoding/struct.go
+++ b/internal/decoding/struct.go
@@ -70,25 +70,10 @@ func (d *decoder) setStruct(rv reflect.Value, offset int, k reflect.Kind) (int, 
 		}
 	*/
 
-	isExt, _, err := d.extEndOffset(offset)
-	if err != nil {
+	if o, ok, err := d.tryExtDecode(rv, offset, k); err != nil {
 		return 0, err
-	}
-	if isExt {
-		for i := range extCoders {
-			if extCoders[i].IsType(offset, &d.data) {
-				v, offset, err := extCoders[i].AsValue(offset, k, &d.data)
-				if err != nil {
-					return 0, err
-				}
-
-				// Validate that the receptacle is of the right value type.
-				if rv.Type() == reflect.TypeOf(v) {
-					rv.Set(reflect.ValueOf(v))
-					return offset, nil
-				}
-			}
-		}
+	} else if ok {
+		return o, nil
 	}
 
 	if d.asArray {

--- a/internal/encoding/benchmark_test.go
+++ b/internal/encoding/benchmark_test.go
@@ -1,0 +1,145 @@
+package encoding
+
+import (
+	"reflect"
+	"testing"
+	stdtime "time"
+
+	"github.com/shamaton/msgpack/v3/def"
+	"github.com/shamaton/msgpack/v3/ext"
+)
+
+type benchmarkStatus int
+type benchmarkStatuses []benchmarkStatus
+
+type benchmarkStruct struct {
+	ID     int64
+	Name   string
+	Active bool
+	Score  float64
+	Tags   []string
+	Data   []byte
+}
+
+type benchmarkIndirect struct {
+	Pointer   *int
+	Interface any
+	Values    []any
+	Nested    [][]int
+}
+
+var (
+	benchmarkBytesResult []byte
+	benchmarkPointerInt  = 42
+	benchmarkIntSlice    = makeBenchmarkInts()
+	benchmarkStatusSlice = makeBenchmarkStatuses()
+	benchmarkStructValue = benchmarkStruct{
+		ID: 42, Name: "benchmark", Active: true, Score: 12.5,
+		Tags: []string{"a", "b", "c", "d"}, Data: make([]byte, 64),
+	}
+	benchmarkTimeValue     = stdtime.Unix(1_700_000_000, 123_456_789)
+	benchmarkIndirectValue = benchmarkIndirect{
+		Pointer:   &benchmarkPointerInt,
+		Interface: int(42),
+		Values:    []any{int(1), "two", []int{3, 4}},
+		Nested:    [][]int{{1, 2}, {3, 4}},
+	}
+)
+
+func makeBenchmarkInts() []int {
+	values := make([]int, 1024)
+	for i := range values {
+		values[i] = i % 128
+	}
+	return values
+}
+
+func makeBenchmarkStatuses() []benchmarkStatus {
+	values := make([]benchmarkStatus, 1024)
+	for i := range values {
+		values[i] = benchmarkStatus(i % 128)
+	}
+	return values
+}
+
+type benchmarkExtEncoder struct {
+	ext.EncoderCommon
+	typ reflect.Type
+}
+
+func (e *benchmarkExtEncoder) Code() int8         { return 42 }
+func (e *benchmarkExtEncoder) Type() reflect.Type { return e.typ }
+func (e *benchmarkExtEncoder) CalcByteSize(reflect.Value) (int, error) {
+	return def.Byte1 + def.Byte1 + def.Byte1, nil
+}
+func (e *benchmarkExtEncoder) WriteToBytes(value reflect.Value, offset int, data *[]byte) int {
+	offset = e.SetByte1Int(def.Fixext1, offset, data)
+	offset = e.SetByte1Int(int(e.Code()), offset, data)
+	return e.SetByte1Int64(valueToInt64(value), offset, data)
+}
+
+func valueToInt64(value reflect.Value) int64 {
+	if value.Kind() == reflect.Slice {
+		return int64(value.Len())
+	}
+	return value.Int()
+}
+
+func benchmarkEncode(b *testing.B, value any) {
+	b.Helper()
+	b.ReportAllocs()
+	if _, err := Encode(value, false); err != nil {
+		b.Fatal(err)
+	}
+	b.ResetTimer()
+	for b.Loop() {
+		encoded, err := Encode(value, false)
+		if err != nil {
+			b.Fatal(err)
+		}
+		benchmarkBytesResult = encoded
+	}
+	b.StopTimer()
+}
+
+func benchmarkEncodeExt(b *testing.B, value any, encoder *benchmarkExtEncoder) {
+	b.Helper()
+	AddExtEncoder(encoder)
+	defer RemoveExtEncoder(encoder)
+	benchmarkEncode(b, value)
+}
+
+func BenchmarkEncodeInt(b *testing.B) {
+	benchmarkEncode(b, int(42))
+}
+
+func BenchmarkEncodeIntSlice(b *testing.B) {
+	benchmarkEncode(b, benchmarkIntSlice)
+}
+
+func BenchmarkEncodeStruct(b *testing.B) {
+	benchmarkEncode(b, benchmarkStructValue)
+}
+
+func BenchmarkEncodeTime(b *testing.B) {
+	benchmarkEncode(b, benchmarkTimeValue)
+}
+
+func BenchmarkEncodeIndirect(b *testing.B) {
+	benchmarkEncode(b, benchmarkIndirectValue)
+}
+
+func BenchmarkEncodeStatus(b *testing.B) {
+	encoder := &benchmarkExtEncoder{typ: reflect.TypeOf(benchmarkStatus(0))}
+	benchmarkEncodeExt(b, benchmarkStatus(42), encoder)
+}
+
+func BenchmarkEncodeStatusSlice(b *testing.B) {
+	encoder := &benchmarkExtEncoder{typ: reflect.TypeOf(benchmarkStatus(0))}
+	benchmarkEncodeExt(b, benchmarkStatusSlice, encoder)
+}
+
+func BenchmarkEncodeStatuses(b *testing.B) {
+	encoder := &benchmarkExtEncoder{typ: reflect.TypeOf(benchmarkStatuses{})}
+	benchmarkEncodeExt(b, benchmarkStatuses(benchmarkStatusSlice), encoder)
+}

--- a/internal/encoding/byte_test.go
+++ b/internal/encoding/byte_test.go
@@ -38,7 +38,7 @@ func Test_calcByteSlice(t *testing.T) {
 	}
 	for _, tc := range testcases {
 		t.Run(tc.name, func(t *testing.T) {
-			e := encoder{}
+			e := encoder{extRegistry: currentExtEncoderRegistry.Load()}
 			result, err := e.calcByteSlice(tc.value)
 			tu.IsError(t, err, tc.error)
 			tu.Equal(t, result, tc.result)

--- a/internal/encoding/defined_type_ext_test.go
+++ b/internal/encoding/defined_type_ext_test.go
@@ -1,0 +1,305 @@
+package encoding
+
+import (
+	"reflect"
+	"sync"
+	"testing"
+
+	"github.com/shamaton/msgpack/v3/def"
+	"github.com/shamaton/msgpack/v3/ext"
+	tu "github.com/shamaton/msgpack/v3/internal/common/testutil"
+)
+
+type issue55Status int
+type issue55OtherStatus int
+type issue55Statuses []issue55Status
+type issue55Bytes []byte
+
+type issue55Holder struct {
+	Status issue55Status
+	Value  any
+}
+
+type issue55ExtEncoder struct {
+	ext.EncoderCommon
+	typ       reflect.Type
+	code      int8
+	marker    byte
+	sawNil    bool
+	writeCall int
+}
+
+func (e *issue55ExtEncoder) Code() int8         { return e.code }
+func (e *issue55ExtEncoder) Type() reflect.Type { return e.typ }
+func (e *issue55ExtEncoder) CalcByteSize(value reflect.Value) (int, error) {
+	if isNilValue(value) {
+		e.sawNil = true
+	}
+	return 3, nil
+}
+func (e *issue55ExtEncoder) WriteToBytes(value reflect.Value, offset int, data *[]byte) int {
+	if isNilValue(value) {
+		e.sawNil = true
+	}
+	e.writeCall++
+	offset = e.SetByte1Int(def.Fixext1, offset, data)
+	offset = e.SetByte1Int(int(e.code), offset, data)
+	return e.SetByte1Uint64(uint64(e.marker), offset, data)
+}
+
+func isNilValue(value reflect.Value) bool {
+	switch value.Kind() {
+	case reflect.Chan, reflect.Func, reflect.Interface, reflect.Map, reflect.Ptr, reflect.Slice:
+		return value.IsNil()
+	default:
+		return false
+	}
+}
+
+func issue55ExtBytes(code int8, marker byte) []byte {
+	return []byte{def.Fixext1, byte(code), marker}
+}
+
+func addIssue55Encoder(t *testing.T, typ reflect.Type, code int8, marker byte) *issue55ExtEncoder {
+	t.Helper()
+	encoder := &issue55ExtEncoder{typ: typ, code: code, marker: marker}
+	AddExtEncoder(encoder)
+	t.Cleanup(func() { RemoveExtEncoder(encoder) })
+	return encoder
+}
+
+func TestDefinedTypeExtEncoderSelection(t *testing.T) {
+	statusType := reflect.TypeOf(issue55Status(0))
+	statusEncoder := addIssue55Encoder(t, statusType, 21, 0xa1)
+	extStatus := issue55ExtBytes(statusEncoder.code, statusEncoder.marker)
+
+	t.Run("root", func(t *testing.T) {
+		encoded, err := Encode(issue55Status(1), false)
+		tu.NoError(t, err)
+		tu.EqualSlice(t, encoded, extStatus)
+	})
+
+	t.Run("struct field", func(t *testing.T) {
+		encoded, err := Encode(issue55Holder{Status: 1}, true)
+		tu.NoError(t, err)
+		expected := append([]byte{def.FixArray + 2}, extStatus...)
+		expected = append(expected, def.Nil)
+		tu.EqualSlice(t, encoded, expected)
+	})
+
+	t.Run("interface field", func(t *testing.T) {
+		encoded, err := Encode(issue55Holder{Value: issue55Status(1)}, true)
+		tu.NoError(t, err)
+		expected := append([]byte{def.FixArray + 2}, extStatus...)
+		expected = append(expected, extStatus...)
+		tu.EqualSlice(t, encoded, expected)
+	})
+
+	t.Run("map key and value", func(t *testing.T) {
+		encoded, err := Encode(map[issue55Status]issue55Status{1: 2}, false)
+		tu.NoError(t, err)
+		expected := append([]byte{def.FixMap + 1}, extStatus...)
+		expected = append(expected, extStatus...)
+		tu.EqualSlice(t, encoded, expected)
+	})
+
+	t.Run("slice elements", func(t *testing.T) {
+		encoded, err := Encode([]issue55Status{1, 2}, false)
+		tu.NoError(t, err)
+		expected := append([]byte{def.FixArray + 2}, extStatus...)
+		expected = append(expected, extStatus...)
+		tu.EqualSlice(t, encoded, expected)
+	})
+}
+
+func TestDefinedTypeWholeContainerExtTakesPrecedence(t *testing.T) {
+	statusEncoder := addIssue55Encoder(t, reflect.TypeOf(issue55Status(0)), 22, 0xb1)
+	statusesEncoder := addIssue55Encoder(t, reflect.TypeOf(issue55Statuses{}), 23, 0xb2)
+
+	encoded, err := Encode(issue55Statuses{1, 2}, false)
+	tu.NoError(t, err)
+	tu.EqualSlice(t, encoded, issue55ExtBytes(statusesEncoder.code, statusesEncoder.marker))
+	tu.Equal(t, statusEncoder.writeCall, 0)
+}
+
+func TestDefinedTypeExtBypassesContainerFastPaths(t *testing.T) {
+	t.Run("defined byte slice", func(t *testing.T) {
+		encoder := addIssue55Encoder(t, reflect.TypeOf(issue55Bytes{}), 24, 0xc1)
+		encoded, err := Encode(issue55Bytes{1, 2}, false)
+		tu.NoError(t, err)
+		tu.EqualSlice(t, encoded, issue55ExtBytes(encoder.code, encoder.marker))
+	})
+
+	t.Run("byte elements", func(t *testing.T) {
+		encoder := addIssue55Encoder(t, reflect.TypeOf(byte(0)), 25, 0xc2)
+		extByte := issue55ExtBytes(encoder.code, encoder.marker)
+		for _, value := range []any{[]byte{1, 2}, [2]byte{1, 2}} {
+			encoded, err := Encode(value, false)
+			tu.NoError(t, err)
+			expected := append([]byte{def.FixArray + 2}, extByte...)
+			expected = append(expected, extByte...)
+			tu.EqualSlice(t, encoded, expected)
+		}
+	})
+
+	t.Run("fixed slice", func(t *testing.T) {
+		encoder := addIssue55Encoder(t, reflect.TypeOf(int(0)), 26, 0xc3)
+		extInt := issue55ExtBytes(encoder.code, encoder.marker)
+		encoded, err := Encode([]int{1, 2}, false)
+		tu.NoError(t, err)
+		expected := append([]byte{def.FixArray + 2}, extInt...)
+		expected = append(expected, extInt...)
+		tu.EqualSlice(t, encoded, expected)
+	})
+
+	t.Run("fixed map", func(t *testing.T) {
+		stringEncoder := addIssue55Encoder(t, reflect.TypeOf(""), 27, 0xc4)
+		intEncoder := addIssue55Encoder(t, reflect.TypeOf(int(0)), 28, 0xc5)
+		encoded, err := Encode(map[string]int{"key": 1}, false)
+		tu.NoError(t, err)
+		expected := append([]byte{def.FixMap + 1}, issue55ExtBytes(stringEncoder.code, stringEncoder.marker)...)
+		expected = append(expected, issue55ExtBytes(intEncoder.code, intEncoder.marker)...)
+		tu.EqualSlice(t, encoded, expected)
+	})
+}
+
+func TestDefinedTypeExtNilAndRemovalSemantics(t *testing.T) {
+	t.Run("nil registered values", func(t *testing.T) {
+		sliceEncoder := addIssue55Encoder(t, reflect.TypeOf(issue55Statuses(nil)), 29, 0xd1)
+		pointerEncoder := addIssue55Encoder(t, reflect.TypeOf((*issue55Status)(nil)), 30, 0xd2)
+
+		encoded, err := Encode(issue55Statuses(nil), false)
+		tu.NoError(t, err)
+		tu.EqualSlice(t, encoded, issue55ExtBytes(sliceEncoder.code, sliceEncoder.marker))
+		tu.Equal(t, sliceEncoder.sawNil, true)
+
+		encoded, err = Encode((*issue55Status)(nil), false)
+		tu.NoError(t, err)
+		tu.EqualSlice(t, encoded, issue55ExtBytes(pointerEncoder.code, pointerEncoder.marker))
+		tu.Equal(t, pointerEncoder.sawNil, true)
+	})
+
+	t.Run("remove restores built-in", func(t *testing.T) {
+		encoder := &issue55ExtEncoder{typ: reflect.TypeOf(issue55Status(0)), code: 31, marker: 0xd3}
+		AddExtEncoder(encoder)
+		RemoveExtEncoder(encoder)
+		encoded, err := Encode(issue55Status(1), false)
+		tu.NoError(t, err)
+		tu.EqualSlice(t, encoded, []byte{1})
+	})
+
+	t.Run("first registration wins", func(t *testing.T) {
+		first := addIssue55Encoder(t, reflect.TypeOf(issue55Status(0)), 32, 0xd4)
+		second := &issue55ExtEncoder{typ: first.typ, code: 33, marker: 0xd5}
+		AddExtEncoder(second)
+		encoded, err := Encode(issue55Status(1), false)
+		tu.NoError(t, err)
+		tu.EqualSlice(t, encoded, issue55ExtBytes(first.code, first.marker))
+	})
+}
+
+func TestExtEncoderRegistryCopyOnWrite(t *testing.T) {
+	typ := reflect.TypeOf(issue55Status(0))
+	before := currentExtEncoderRegistry.Load()
+	encoder := &issue55ExtEncoder{typ: typ, code: 34, marker: 0xe1}
+
+	AddExtEncoder(encoder)
+	afterAdd := currentExtEncoderRegistry.Load()
+	if before == afterAdd {
+		t.Fatal("registration must publish a new registry snapshot")
+	}
+	if before.byKind[reflect.Int] != nil {
+		t.Fatal("published old snapshot was mutated")
+	}
+	if afterAdd.byKind[reflect.Int][typ] != encoder {
+		t.Fatal("new snapshot does not contain encoder")
+	}
+	if afterAdd.customCount != before.customCount+1 || !afterAdd.hasCustom[reflect.Int] {
+		t.Fatal("new snapshot does not enable the custom kind fast-path flag")
+	}
+
+	RemoveExtEncoder(encoder)
+	afterRemove := currentExtEncoderRegistry.Load()
+	if afterAdd.byKind[reflect.Int][typ] != encoder {
+		t.Fatal("published added snapshot was mutated")
+	}
+	if afterRemove.byKind[reflect.Int] != nil {
+		t.Fatal("last removal must restore nil kind bucket")
+	}
+	if afterRemove.customCount != before.customCount || afterRemove.hasCustom[reflect.Int] {
+		t.Fatal("last removal must restore the no-custom fast path")
+	}
+}
+
+func TestExtEncoderRegistryKeepsKindFlagAfterPartialRemoval(t *testing.T) {
+	first := &issue55ExtEncoder{typ: reflect.TypeOf(issue55Status(0)), code: 37, marker: 0xf3}
+	second := &issue55ExtEncoder{typ: reflect.TypeOf(issue55OtherStatus(0)), code: 38, marker: 0xf4}
+	AddExtEncoder(first)
+	AddExtEncoder(second)
+	t.Cleanup(func() {
+		RemoveExtEncoder(first)
+		RemoveExtEncoder(second)
+	})
+
+	RemoveExtEncoder(first)
+	registry := currentExtEncoderRegistry.Load()
+	if !registry.hasCustom[reflect.Int] {
+		t.Fatal("partial removal must keep the custom kind flag")
+	}
+	if registry.byKind[reflect.Int][second.typ] != second {
+		t.Fatal("partial removal lost the remaining encoder")
+	}
+	encoded, err := Encode(issue55OtherStatus(1), false)
+	tu.NoError(t, err)
+	tu.EqualSlice(t, encoded, issue55ExtBytes(second.code, second.marker))
+}
+
+type issue55BlockingEncoder struct {
+	*issue55ExtEncoder
+	started chan struct{}
+	release chan struct{}
+	once    sync.Once
+}
+
+func (e *issue55BlockingEncoder) CalcByteSize(value reflect.Value) (int, error) {
+	e.once.Do(func() {
+		close(e.started)
+		<-e.release
+	})
+	return e.issue55ExtEncoder.CalcByteSize(value)
+}
+
+func TestEncodeUsesSingleExtRegistrySnapshot(t *testing.T) {
+	typ := reflect.TypeOf(issue55Status(0))
+	first := &issue55BlockingEncoder{
+		issue55ExtEncoder: &issue55ExtEncoder{typ: typ, code: 35, marker: 0xf1},
+		started:           make(chan struct{}),
+		release:           make(chan struct{}),
+	}
+	second := &issue55ExtEncoder{typ: typ, code: 36, marker: 0xf2}
+	AddExtEncoder(first)
+
+	type result struct {
+		data []byte
+		err  error
+	}
+	resultCh := make(chan result, 1)
+	go func() {
+		data, err := Encode(issue55Status(1), false)
+		resultCh <- result{data: data, err: err}
+	}()
+
+	<-first.started
+	RemoveExtEncoder(first)
+	AddExtEncoder(second)
+	close(first.release)
+
+	encoded := <-resultCh
+	tu.NoError(t, encoded.err)
+	tu.EqualSlice(t, encoded.data, issue55ExtBytes(first.code, first.marker))
+
+	next, err := Encode(issue55Status(1), false)
+	tu.NoError(t, err)
+	tu.EqualSlice(t, next, issue55ExtBytes(second.code, second.marker))
+	RemoveExtEncoder(second)
+}

--- a/internal/encoding/encoding.go
+++ b/internal/encoding/encoding.go
@@ -6,12 +6,14 @@ import (
 	"reflect"
 
 	"github.com/shamaton/msgpack/v3/def"
+	"github.com/shamaton/msgpack/v3/ext"
 	"github.com/shamaton/msgpack/v3/internal/common"
 )
 
 type encoder struct {
-	d       []byte
-	asArray bool
+	d           []byte
+	asArray     bool
+	extRegistry *extEncoderRegistry
 	common.Common
 	mk map[uintptr][]reflect.Value
 	mv map[uintptr][]reflect.Value
@@ -19,7 +21,10 @@ type encoder struct {
 
 // Encode returns the MessagePack-encoded byte array of v.
 func Encode(v interface{}, asArray bool) (b []byte, err error) {
-	e := encoder{asArray: asArray}
+	e := encoder{
+		asArray:     asArray,
+		extRegistry: currentExtEncoderRegistry.Load(),
+	}
 	/*
 		defer func() {
 			e := recover()
@@ -31,19 +36,24 @@ func Encode(v interface{}, asArray bool) (b []byte, err error) {
 	*/
 
 	rv := reflect.ValueOf(v)
-	if rv.Kind() == reflect.Ptr {
-		rv = rv.Elem()
-		if rv.Kind() == reflect.Ptr {
-			rv = rv.Elem()
-		}
+	noCustom := e.extRegistry.customCount == 0
+	var size int
+	if noCustom {
+		size, err = e.calcSizeBuiltIn(rv)
+	} else {
+		size, err = e.calcSize(rv)
 	}
-	size, err := e.calcSize(rv)
 	if err != nil {
 		return nil, err
 	}
 
 	e.d = make([]byte, size)
-	last := e.create(rv, 0)
+	var last int
+	if noCustom {
+		last = e.createBuiltIn(rv, 0)
+	} else {
+		last = e.create(rv, 0)
+	}
 	if size != last {
 		return nil, fmt.Errorf("%w size=%d, lastIdx=%d", def.ErrNotMatchLastIndex, size, last)
 	}
@@ -63,7 +73,22 @@ func Encode(v interface{}, asArray bool) (b []byte, err error) {
 //}
 
 func (e *encoder) calcSize(rv reflect.Value) (int, error) {
-	switch rv.Kind() {
+	kind := rv.Kind()
+	if kind == reflect.Invalid {
+		return def.Byte1, nil
+	}
+	if encoder, ok := e.extEncoderForValue(kind, rv); ok {
+		return encoder.CalcByteSize(rv)
+	}
+	return e.calcSizeByKind(rv, kind)
+}
+
+func (e *encoder) calcSizeDefault(rv reflect.Value) (int, error) {
+	return e.calcSizeByKind(rv, rv.Kind())
+}
+
+func (e *encoder) calcSizeByKind(rv reflect.Value, kind reflect.Kind) (int, error) {
+	switch kind {
 	case reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64, reflect.Uint:
 		v := rv.Uint()
 		return e.calcUint(v), nil
@@ -94,8 +119,15 @@ func (e *encoder) calcSize(rv reflect.Value) (int, error) {
 		if rv.IsNil() {
 			return def.Byte1, nil
 		}
+		var elementType reflect.Type
+		var elementEncoder ext.Encoder
+		var elementHasExt bool
+		if e.extRegistry.customCount != 0 {
+			elementType = rv.Type().Elem()
+			elementEncoder, elementHasExt = e.extEncoderForType(elementType)
+		}
 		// bin format
-		if e.isByteSlice(rv) {
+		if !elementHasExt && e.isByteSlice(rv) {
 			size, err := e.calcByteSlice(rv.Len())
 			if err != nil {
 				return 0, err
@@ -103,17 +135,14 @@ func (e *encoder) calcSize(rv reflect.Value) (int, error) {
 			return size, nil
 		}
 
-		if size, find := e.calcFixedSlice(rv); find {
-			return size, nil
+		if !elementHasExt {
+			if size, find := e.calcFixedSlice(rv); find {
+				return size, nil
+			}
 		}
-
-		// func
-		elem := rv.Type().Elem()
-		var f structCalcFunc
-		if elem.Kind() == reflect.Struct {
-			f = e.getStructCalc(elem)
-		} else {
-			f = e.calcSize
+		if elementType == nil {
+			elementType = rv.Type().Elem()
+			elementEncoder, elementHasExt = e.extEncoderForType(elementType)
 		}
 
 		l := rv.Len()
@@ -122,9 +151,25 @@ func (e *encoder) calcSize(rv reflect.Value) (int, error) {
 			return 0, err
 		}
 
-		// objects size
+		if elementHasExt {
+			for i := 0; i < l; i++ {
+				s, err := elementEncoder.CalcByteSize(rv.Index(i))
+				if err != nil {
+					return 0, err
+				}
+				size += s
+			}
+			return size, nil
+		}
+
+		calcElement := e.calcSizeDefault
+		if e.extRegistry.customCount == 0 {
+			calcElement = e.calcSizeBuiltIn
+		} else if elementType.Kind() == reflect.Struct {
+			calcElement = e.getStructCalc(elementType)
+		}
 		for i := 0; i < l; i++ {
-			s, err := f(rv.Index(i))
+			s, err := calcElement(rv.Index(i))
 			if err != nil {
 				return 0, err
 			}
@@ -133,22 +178,24 @@ func (e *encoder) calcSize(rv reflect.Value) (int, error) {
 		return size, nil
 
 	case reflect.Array:
+		var elementType reflect.Type
+		var elementEncoder ext.Encoder
+		var elementHasExt bool
+		if e.extRegistry.customCount != 0 {
+			elementType = rv.Type().Elem()
+			elementEncoder, elementHasExt = e.extEncoderForType(elementType)
+		}
 		// bin format
-		if e.isByteSlice(rv) {
+		if !elementHasExt && e.isByteSlice(rv) {
 			size, err := e.calcByteSlice(rv.Len())
 			if err != nil {
 				return 0, err
 			}
 			return size, nil
 		}
-
-		// func
-		elem := rv.Type().Elem()
-		var f structCalcFunc
-		if elem.Kind() == reflect.Struct {
-			f = e.getStructCalc(elem)
-		} else {
-			f = e.calcSize
+		if elementType == nil {
+			elementType = rv.Type().Elem()
+			elementEncoder, elementHasExt = e.extEncoderForType(elementType)
 		}
 
 		l := rv.Len()
@@ -157,9 +204,25 @@ func (e *encoder) calcSize(rv reflect.Value) (int, error) {
 			return 0, err
 		}
 
-		// objects size
+		if elementHasExt {
+			for i := 0; i < l; i++ {
+				s, err := elementEncoder.CalcByteSize(rv.Index(i))
+				if err != nil {
+					return 0, err
+				}
+				size += s
+			}
+			return size, nil
+		}
+
+		calcElement := e.calcSizeDefault
+		if e.extRegistry.customCount == 0 {
+			calcElement = e.calcSizeBuiltIn
+		} else if elementType.Kind() == reflect.Struct {
+			calcElement = e.getStructCalc(elementType)
+		}
 		for i := 0; i < l; i++ {
-			s, err := f(rv.Index(i))
+			s, err := calcElement(rv.Index(i))
 			if err != nil {
 				return 0, err
 			}
@@ -172,8 +235,20 @@ func (e *encoder) calcSize(rv reflect.Value) (int, error) {
 			return def.Byte1, nil
 		}
 
-		if size, find := e.calcFixedMap(rv); find {
-			return size, nil
+		var keyEncoder, valueEncoder ext.Encoder
+		var keyHasExt, valueHasExt bool
+		if e.extRegistry.customCount != 0 {
+			keyEncoder, keyHasExt = e.extEncoderForType(rv.Type().Key())
+			valueEncoder, valueHasExt = e.extEncoderForType(rv.Type().Elem())
+		}
+		if !keyHasExt && !valueHasExt {
+			if size, find := e.calcFixedMap(rv); find {
+				return size, nil
+			}
+		}
+		if e.extRegistry.customCount == 0 {
+			keyEncoder, keyHasExt = e.extEncoderForType(rv.Type().Key())
+			valueEncoder, valueHasExt = e.extEncoderForType(rv.Type().Elem())
 		}
 
 		if e.mk == nil {
@@ -191,12 +266,26 @@ func (e *encoder) calcSize(rv reflect.Value) (int, error) {
 		mv := make([]reflect.Value, len(keys))
 		i := 0
 		for _, k := range keys {
-			keySize, err := e.calcSize(k)
+			var keySize int
+			if keyHasExt {
+				keySize, err = keyEncoder.CalcByteSize(k)
+			} else if e.extRegistry.customCount == 0 {
+				keySize, err = e.calcSizeBuiltIn(k)
+			} else {
+				keySize, err = e.calcSizeDefault(k)
+			}
 			if err != nil {
 				return 0, err
 			}
 			value := rv.MapIndex(k)
-			valueSize, err := e.calcSize(value)
+			var valueSize int
+			if valueHasExt {
+				valueSize, err = valueEncoder.CalcByteSize(value)
+			} else if e.extRegistry.customCount == 0 {
+				valueSize, err = e.calcSizeBuiltIn(value)
+			} else {
+				valueSize, err = e.calcSizeDefault(value)
+			}
 			if err != nil {
 				return 0, err
 			}
@@ -218,25 +307,29 @@ func (e *encoder) calcSize(rv reflect.Value) (int, error) {
 		if rv.IsNil() {
 			return def.Byte1, nil
 		}
-		size, err := e.calcSize(rv.Elem())
+		calcElement := e.calcSize
+		if e.extRegistry.customCount == 0 {
+			calcElement = e.calcSizeBuiltIn
+		}
+		size, err := calcElement(rv.Elem())
 		if err != nil {
 			return 0, err
 		}
 		return size, nil
 
 	case reflect.Interface:
-		size, err := e.calcSize(rv.Elem())
+		calcElement := e.calcSize
+		if e.extRegistry.customCount == 0 {
+			calcElement = e.calcSizeBuiltIn
+		}
+		size, err := calcElement(rv.Elem())
 		if err != nil {
 			return 0, err
 		}
 		return size, nil
 
-	case reflect.Invalid:
-		// do nothing (return nil)
-		return def.Byte1, nil
-
 	default:
-		return 0, fmt.Errorf("%v is %w type", rv.Kind(), def.ErrUnsupportedType)
+		return 0, fmt.Errorf("%v is %w type", kind, def.ErrUnsupportedType)
 	}
 }
 
@@ -253,7 +346,29 @@ func (e *encoder) calcLength(l int) (int, error) {
 }
 
 func (e *encoder) create(rv reflect.Value, offset int) int {
-	switch rv.Kind() {
+	kind := rv.Kind()
+	if kind == reflect.Invalid {
+		return e.writeNil(offset)
+	}
+	if encoder, ok := e.extEncoderForValue(kind, rv); ok {
+		return e.writeExt(encoder, rv, offset)
+	}
+	return e.createByKind(rv, kind, offset)
+}
+
+func (e *encoder) createDefault(rv reflect.Value, offset int) int {
+	return e.createByKind(rv, rv.Kind(), offset)
+}
+
+func (e *encoder) writeExt(encoder ext.Encoder, rv reflect.Value, offset int) int {
+	data := e.d
+	offset = encoder.WriteToBytes(rv, offset, &data)
+	e.d = data
+	return offset
+}
+
+func (e *encoder) createByKind(rv reflect.Value, kind reflect.Kind, offset int) int {
+	switch kind {
 	case reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64, reflect.Uint:
 		v := rv.Uint()
 		offset = e.writeUint(v, offset)
@@ -284,38 +399,63 @@ func (e *encoder) create(rv reflect.Value, offset int) int {
 		if rv.IsNil() {
 			return e.writeNil(offset)
 		}
+		var elementType reflect.Type
+		var elementEncoder ext.Encoder
+		var elementHasExt bool
+		if e.extRegistry.customCount != 0 {
+			elementType = rv.Type().Elem()
+			elementEncoder, elementHasExt = e.extEncoderForType(elementType)
+		}
 
 		// bin format
-		if e.isByteSlice(rv) {
+		if !elementHasExt && e.isByteSlice(rv) {
 			offset = e.writeByteSliceLength(rv.Len(), offset)
 			offset = e.setBytes(rv.Bytes(), offset)
 			return offset
 		}
 
-		if offset, find := e.writeFixedSlice(rv, offset); find {
-			return offset
+		if !elementHasExt {
+			if offset, find := e.writeFixedSlice(rv, offset); find {
+				return offset
+			}
 		}
-
-		// func
-		elem := rv.Type().Elem()
-		var f structWriteFunc
-		if elem.Kind() == reflect.Struct {
-			f = e.getStructWriter(elem)
-		} else {
-			f = e.create
+		if elementType == nil {
+			elementType = rv.Type().Elem()
+			elementEncoder, elementHasExt = e.extEncoderForType(elementType)
 		}
 
 		// objects
 		l := rv.Len()
 		offset = e.writeSliceLength(l, offset)
+		if elementHasExt {
+			data := e.d
+			for i := 0; i < l; i++ {
+				offset = elementEncoder.WriteToBytes(rv.Index(i), offset, &data)
+			}
+			e.d = data
+			return offset
+		}
+		writeElement := e.createDefault
+		if e.extRegistry.customCount == 0 {
+			writeElement = e.createBuiltIn
+		} else if elementType.Kind() == reflect.Struct {
+			writeElement = e.getStructWriter(elementType)
+		}
 		for i := 0; i < l; i++ {
-			offset = f(rv.Index(i), offset)
+			offset = writeElement(rv.Index(i), offset)
 		}
 
 	case reflect.Array:
 		l := rv.Len()
+		var elementType reflect.Type
+		var elementEncoder ext.Encoder
+		var elementHasExt bool
+		if e.extRegistry.customCount != 0 {
+			elementType = rv.Type().Elem()
+			elementEncoder, elementHasExt = e.extEncoderForType(elementType)
+		}
 		// bin format
-		if e.isByteSlice(rv) {
+		if !elementHasExt && e.isByteSlice(rv) {
 			offset = e.writeByteSliceLength(l, offset)
 			// objects
 			for i := 0; i < l; i++ {
@@ -323,22 +463,30 @@ func (e *encoder) create(rv reflect.Value, offset int) int {
 			}
 			return offset
 		}
+		if elementType == nil {
+			elementType = rv.Type().Elem()
+			elementEncoder, elementHasExt = e.extEncoderForType(elementType)
+		}
 
 		// format
 		offset = e.writeSliceLength(l, offset)
 
-		// func
-		elem := rv.Type().Elem()
-		var f structWriteFunc
-		if elem.Kind() == reflect.Struct {
-			f = e.getStructWriter(elem)
-		} else {
-			f = e.create
+		if elementHasExt {
+			data := e.d
+			for i := 0; i < l; i++ {
+				offset = elementEncoder.WriteToBytes(rv.Index(i), offset, &data)
+			}
+			e.d = data
+			return offset
 		}
-
-		// objects
+		writeElement := e.createDefault
+		if e.extRegistry.customCount == 0 {
+			writeElement = e.createBuiltIn
+		} else if elementType.Kind() == reflect.Struct {
+			writeElement = e.getStructWriter(elementType)
+		}
 		for i := 0; i < l; i++ {
-			offset = f(rv.Index(i), offset)
+			offset = writeElement(rv.Index(i), offset)
 		}
 
 	case reflect.Map:
@@ -349,16 +497,48 @@ func (e *encoder) create(rv reflect.Value, offset int) int {
 		l := rv.Len()
 		offset = e.writeMapLength(l, offset)
 
-		if offset, find := e.writeFixedMap(rv, offset); find {
-			return offset
+		var keyEncoder, valueEncoder ext.Encoder
+		var keyHasExt, valueHasExt bool
+		if e.extRegistry.customCount != 0 {
+			keyEncoder, keyHasExt = e.extEncoderForType(rv.Type().Key())
+			valueEncoder, valueHasExt = e.extEncoderForType(rv.Type().Elem())
+		}
+		if !keyHasExt && !valueHasExt {
+			if offset, find := e.writeFixedMap(rv, offset); find {
+				return offset
+			}
+		}
+		if e.extRegistry.customCount == 0 {
+			keyEncoder, keyHasExt = e.extEncoderForType(rv.Type().Key())
+			valueEncoder, valueHasExt = e.extEncoderForType(rv.Type().Elem())
 		}
 
 		// key-value
 		p := rv.Pointer()
+		data := e.d
 		for i := range e.mk[p] {
-			offset = e.create(e.mk[p][i], offset)
-			offset = e.create(e.mv[p][i], offset)
+			if keyHasExt {
+				offset = keyEncoder.WriteToBytes(e.mk[p][i], offset, &data)
+				e.d = data
+			} else if e.extRegistry.customCount == 0 {
+				offset = e.createBuiltIn(e.mk[p][i], offset)
+				data = e.d
+			} else {
+				offset = e.createDefault(e.mk[p][i], offset)
+				data = e.d
+			}
+			if valueHasExt {
+				offset = valueEncoder.WriteToBytes(e.mv[p][i], offset, &data)
+				e.d = data
+			} else if e.extRegistry.customCount == 0 {
+				offset = e.createBuiltIn(e.mv[p][i], offset)
+				data = e.d
+			} else {
+				offset = e.createDefault(e.mv[p][i], offset)
+				data = e.d
+			}
 		}
+		e.d = data
 
 	case reflect.Struct:
 		offset = e.writeStruct(rv, offset)
@@ -368,13 +548,18 @@ func (e *encoder) create(rv reflect.Value, offset int) int {
 			return e.writeNil(offset)
 		}
 
-		offset = e.create(rv.Elem(), offset)
+		if e.extRegistry.customCount == 0 {
+			offset = e.createBuiltIn(rv.Elem(), offset)
+		} else {
+			offset = e.create(rv.Elem(), offset)
+		}
 
 	case reflect.Interface:
-		offset = e.create(rv.Elem(), offset)
-
-	case reflect.Invalid:
-		return e.writeNil(offset)
+		if e.extRegistry.customCount == 0 {
+			offset = e.createBuiltIn(rv.Elem(), offset)
+		} else {
+			offset = e.create(rv.Elem(), offset)
+		}
 
 	}
 	return offset

--- a/internal/encoding/encoding_test.go
+++ b/internal/encoding/encoding_test.go
@@ -35,7 +35,7 @@ func Test_encode(t *testing.T) {
 		for _, tc := range tcs {
 			rv := reflect.ValueOf(tc.value)
 			t.Run(rv.Type().String(), func(t *testing.T) {
-				e := encoder{}
+				e := encoder{extRegistry: currentExtEncoderRegistry.Load()}
 				size, err := e.calcSize(rv)
 				tu.IsError(t, err, tc.error)
 				if err != nil {
@@ -224,7 +224,7 @@ func Test_encode(t *testing.T) {
 }
 
 func Test_calcLength(t *testing.T) {
-	e := encoder{}
+	e := encoder{extRegistry: currentExtEncoderRegistry.Load()}
 
 	testcases := []struct {
 		name   string

--- a/internal/encoding/ext.go
+++ b/internal/encoding/ext.go
@@ -2,98 +2,211 @@ package encoding
 
 import (
 	"reflect"
+	"sync"
+	"sync/atomic"
 
+	"github.com/shamaton/msgpack/v3/def"
 	"github.com/shamaton/msgpack/v3/ext"
 	"github.com/shamaton/msgpack/v3/time"
 )
 
+type extEncoderRegistry struct {
+	byKind      [reflect.UnsafePointer + 1]map[reflect.Type]ext.Encoder
+	hasCustom   [reflect.UnsafePointer + 1]bool
+	customCount int
+}
+
 var (
-	extCoderMap = map[reflect.Type]ext.Encoder{time.Encoder.Type(): time.Encoder}
-	extCoders   = []ext.Encoder{time.Encoder}
+	extEncoderRegistryMu      sync.Mutex
+	currentExtEncoderRegistry atomic.Pointer[extEncoderRegistry]
+	builtInTimeType           = time.Encoder.Type()
 )
 
-// AddExtEncoder adds encoders for extension types.
-func AddExtEncoder(f ext.Encoder) {
-	// ignore time
-	if f.Type() == time.Encoder.Type() {
+func init() {
+	registry := &extEncoderRegistry{}
+	registry.byKind[reflect.Struct] = map[reflect.Type]ext.Encoder{
+		builtInTimeType: time.Encoder,
+	}
+	currentExtEncoderRegistry.Store(registry)
+}
+
+// AddExtEncoder adds an encoder for an exact type without replacing an existing encoder.
+func AddExtEncoder(encoder ext.Encoder) {
+	typ := encoder.Type()
+	if typ == builtInTimeType {
 		return
 	}
 
-	_, ok := extCoderMap[f.Type()]
-	if !ok {
-		extCoderMap[f.Type()] = f
-		updateExtCoders()
-	}
-}
+	extEncoderRegistryMu.Lock()
+	defer extEncoderRegistryMu.Unlock()
 
-// RemoveExtEncoder removes encoders for extension types.
-func RemoveExtEncoder(f ext.Encoder) {
-	// ignore time
-	if f.Type() == time.Encoder.Type() {
+	current := currentExtEncoderRegistry.Load()
+	kind := typ.Kind()
+	if _, exists := current.byKind[kind][typ]; exists {
 		return
 	}
 
-	_, ok := extCoderMap[f.Type()]
-	if ok {
-		delete(extCoderMap, f.Type())
-		updateExtCoders()
-	}
+	next := *current
+	next.byKind[kind] = cloneExtEncoderMap(current.byKind[kind], 1)
+	next.byKind[kind][typ] = encoder
+	next.hasCustom[kind] = true
+	next.customCount++
+	currentExtEncoderRegistry.Store(&next)
 }
 
-func updateExtCoders() {
-	extCoders = make([]ext.Encoder, len(extCoderMap))
-	i := 0
-	for k := range extCoderMap {
-		extCoders[i] = extCoderMap[k]
-		i++
+// RemoveExtEncoder removes the encoder registered for the encoder's exact type.
+func RemoveExtEncoder(encoder ext.Encoder) {
+	typ := encoder.Type()
+	if typ == builtInTimeType {
+		return
 	}
+
+	extEncoderRegistryMu.Lock()
+	defer extEncoderRegistryMu.Unlock()
+
+	current := currentExtEncoderRegistry.Load()
+	kind := typ.Kind()
+	currentKind := current.byKind[kind]
+	if _, exists := currentKind[typ]; !exists {
+		return
+	}
+
+	next := *current
+	if len(currentKind) == 1 {
+		next.byKind[kind] = nil
+		next.hasCustom[kind] = false
+	} else {
+		next.byKind[kind] = cloneExtEncoderMap(currentKind, 0)
+		delete(next.byKind[kind], typ)
+		next.hasCustom[kind] = kind != reflect.Struct || len(next.byKind[kind]) > 1
+	}
+	next.customCount--
+	currentExtEncoderRegistry.Store(&next)
 }
 
-/*
-func (e *encoder) isDateTime(value reflect.Value) (bool, time.Time) {
-	i := value.Interface()
-	switch t := i.(type) {
-	case time.Time:
-		return true, t
+func cloneExtEncoderMap(source map[reflect.Type]ext.Encoder, extraCapacity int) map[reflect.Type]ext.Encoder {
+	cloned := make(map[reflect.Type]ext.Encoder, len(source)+extraCapacity)
+	for typ, encoder := range source {
+		cloned[typ] = encoder
 	}
-	return false, now
+	return cloned
 }
 
-func (e *encoder) calcTime(t time.Time) int {
-	secs := uint64(t.Unix())
-	if secs>>34 == 0 {
-		data := uint64(t.Nanosecond())<<34 | secs
-		if data&0xffffffff00000000 == 0 {
-			return def.Byte1 + def.Byte4
+func (e *encoder) extEncoderForValue(kind reflect.Kind, value reflect.Value) (ext.Encoder, bool) {
+	if e.extRegistry.customCount == 0 {
+		if kind == reflect.Struct && value.Type() == builtInTimeType {
+			return time.Encoder, true
 		}
-		return def.Byte1 + def.Byte8
+		return nil, false
 	}
-
-	return def.Byte1 + def.Byte1 + def.Byte4 + def.Byte8
-}
-
-func (e *encoder) writeTime(t time.Time, offset int) int {
-	secs := uint64(t.Unix())
-	if secs>>34 == 0 {
-		data := uint64(t.Nanosecond())<<34 | secs
-		if data&0xffffffff00000000 == 0 {
-			offset = e.setByte1Int(def.Fixext4, offset)
-			offset = e.setByte1Int(def.TimeStamp, offset)
-			offset = e.setByte4Uint64(data, offset)
-			return offset
+	if kind == reflect.Struct && !e.extRegistry.hasCustom[reflect.Struct] {
+		if value.Type() == builtInTimeType {
+			return time.Encoder, true
 		}
-
-		offset = e.setByte1Int(def.Fixext8, offset)
-		offset = e.setByte1Int(def.TimeStamp, offset)
-		offset = e.setByte8Uint64(data, offset)
-		return offset
+		return nil, false
 	}
-
-	offset = e.setByte1Int(def.Ext8, offset)
-	offset = e.setByte1Int(12, offset)
-	offset = e.setByte1Int(def.TimeStamp, offset)
-	offset = e.setByte4Int(t.Nanosecond(), offset)
-	offset = e.setByte8Uint64(secs, offset)
-	return offset
+	coders := e.extRegistry.byKind[kind]
+	if coders == nil {
+		return nil, false
+	}
+	encoder, ok := coders[value.Type()]
+	return encoder, ok
 }
-*/
+
+func (e *encoder) extEncoderForType(typ reflect.Type) (ext.Encoder, bool) {
+	kind := typ.Kind()
+	if e.extRegistry.customCount == 0 {
+		if kind == reflect.Struct && typ == builtInTimeType {
+			return time.Encoder, true
+		}
+		return nil, false
+	}
+	if kind == reflect.Struct && !e.extRegistry.hasCustom[reflect.Struct] {
+		if typ == builtInTimeType {
+			return time.Encoder, true
+		}
+		return nil, false
+	}
+	coders := e.extRegistry.byKind[kind]
+	if coders == nil {
+		return nil, false
+	}
+	encoder, ok := coders[typ]
+	return encoder, ok
+}
+
+func (e *encoder) calcSizeBuiltIn(rv reflect.Value) (int, error) {
+	kind := rv.Kind()
+	switch kind {
+	case reflect.Invalid:
+		return def.Byte1, nil
+	case reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64, reflect.Uint:
+		return e.calcUint(rv.Uint()), nil
+	case reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64, reflect.Int:
+		return e.calcInt(rv.Int()), nil
+	case reflect.Float32:
+		return e.calcFloat32(0), nil
+	case reflect.Float64:
+		return e.calcFloat64(0), nil
+	case reflect.String:
+		return e.calcString(rv.String()), nil
+	case reflect.Bool:
+		return def.Byte1, nil
+	case reflect.Complex64:
+		return e.calcComplex64(), nil
+	case reflect.Complex128:
+		return e.calcComplex128(), nil
+	case reflect.Struct:
+		if rv.Type() == builtInTimeType {
+			return time.Encoder.CalcByteSize(rv)
+		}
+		return e.calcStruct(rv)
+	case reflect.Ptr:
+		if rv.IsNil() {
+			return def.Byte1, nil
+		}
+		return e.calcSizeBuiltIn(rv.Elem())
+	case reflect.Interface:
+		return e.calcSizeBuiltIn(rv.Elem())
+	default:
+		return e.calcSizeByKind(rv, kind)
+	}
+}
+
+func (e *encoder) createBuiltIn(rv reflect.Value, offset int) int {
+	kind := rv.Kind()
+	switch kind {
+	case reflect.Invalid:
+		return e.writeNil(offset)
+	case reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64, reflect.Uint:
+		return e.writeUint(rv.Uint(), offset)
+	case reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64, reflect.Int:
+		return e.writeInt(rv.Int(), offset)
+	case reflect.Float32:
+		return e.writeFloat32(rv.Float(), offset)
+	case reflect.Float64:
+		return e.writeFloat64(rv.Float(), offset)
+	case reflect.Bool:
+		return e.writeBool(rv.Bool(), offset)
+	case reflect.String:
+		return e.writeString(rv.String(), offset)
+	case reflect.Complex64:
+		return e.writeComplex64(complex64(rv.Complex()), offset)
+	case reflect.Complex128:
+		return e.writeComplex128(rv.Complex(), offset)
+	case reflect.Struct:
+		if rv.Type() == builtInTimeType {
+			return e.writeExt(time.Encoder, rv, offset)
+		}
+		return e.writeStruct(rv, offset)
+	case reflect.Ptr:
+		if rv.IsNil() {
+			return e.writeNil(offset)
+		}
+		return e.createBuiltIn(rv.Elem(), offset)
+	case reflect.Interface:
+		return e.createBuiltIn(rv.Elem(), offset)
+	default:
+		return e.createByKind(rv, kind, offset)
+	}
+}

--- a/internal/encoding/ext_test.go
+++ b/internal/encoding/ext_test.go
@@ -1,8 +1,10 @@
 package encoding
 
 import (
+	"reflect"
 	"testing"
 
+	"github.com/shamaton/msgpack/v3/ext"
 	tu "github.com/shamaton/msgpack/v3/internal/common/testutil"
 	"github.com/shamaton/msgpack/v3/time"
 )
@@ -10,13 +12,17 @@ import (
 func Test_AddExtEncoder(t *testing.T) {
 	t.Run("ignore", func(t *testing.T) {
 		AddExtEncoder(time.Encoder)
-		tu.Equal(t, len(extCoders), 1)
+		coders := currentExtEncoderRegistry.Load().byKind[reflect.Struct]
+		tu.Equal(t, len(coders), 1)
+		tu.Equal(t, coders[time.Encoder.Type()], ext.Encoder(time.Encoder))
 	})
 }
 
 func Test_RemoveExtEncoder(t *testing.T) {
 	t.Run("ignore", func(t *testing.T) {
 		RemoveExtEncoder(time.Encoder)
-		tu.Equal(t, len(extCoders), 1)
+		coders := currentExtEncoderRegistry.Load().byKind[reflect.Struct]
+		tu.Equal(t, len(coders), 1)
+		tu.Equal(t, coders[time.Encoder.Type()], ext.Encoder(time.Encoder))
 	})
 }

--- a/internal/encoding/slice_test.go
+++ b/internal/encoding/slice_test.go
@@ -72,7 +72,7 @@ func Test_FixedSlice(t *testing.T) {
 	for _, tc := range testcases {
 		rv := reflect.ValueOf(tc.value)
 		t.Run(rv.Type().String(), func(t *testing.T) {
-			e := encoder{}
+			e := encoder{extRegistry: currentExtEncoderRegistry.Load()}
 			size, b := e.calcFixedSlice(rv)
 			tu.Equal(t, b, true)
 			tu.Equal(t, size, tc.size)

--- a/internal/encoding/struct.go
+++ b/internal/encoding/struct.go
@@ -62,12 +62,7 @@ func shouldOmitByParent(rv reflect.Value, omitPaths [][]int) bool {
 	return false
 }
 
-func (e *encoder) getStructCalc(typ reflect.Type) structCalcFunc {
-	for j := range extCoders {
-		if extCoders[j].Type() == typ {
-			return extCoders[j].CalcByteSize
-		}
-	}
+func (e *encoder) getStructCalc(_ reflect.Type) structCalcFunc {
 	if e.asArray {
 		return e.calcStructArray
 	}
@@ -79,12 +74,6 @@ func (e *encoder) calcStruct(rv reflect.Value) (int, error) {
 	//	size := e.calcTime(tm)
 	//	return size, nil
 	//}
-
-	for i := range extCoders {
-		if extCoders[i].Type() == rv.Type() {
-			return extCoders[i].CalcByteSize(rv)
-		}
-	}
 
 	if e.asArray {
 		return e.calcStructArray(rv)
@@ -130,30 +119,55 @@ func (e *encoder) calcStructArray(rv reflect.Value) (int, error) {
 	} else {
 		c = cache.(*structCache)
 	}
+	noCustom := e.extRegistry.customCount == 0
 
 	// calculate size based on path type
 	var numFields int
 	if c.hasEmbedded {
 		numFields = len(c.indexes)
-		for i := 0; i < numFields; i++ {
-			fieldValue, ok := getFieldByPath(rv, c.indexes[i])
-			if shouldOmitByParent(rv, c.omitPaths[i]) || !ok {
-				fieldValue = reflect.Value{}
+		if noCustom {
+			for i := 0; i < numFields; i++ {
+				fieldValue, ok := getFieldByPath(rv, c.indexes[i])
+				if shouldOmitByParent(rv, c.omitPaths[i]) || !ok {
+					fieldValue = reflect.Value{}
+				}
+				size, err := e.calcSizeBuiltIn(fieldValue)
+				if err != nil {
+					return 0, err
+				}
+				ret += size
 			}
-			size, err := e.calcSize(fieldValue)
-			if err != nil {
-				return 0, err
+		} else {
+			for i := 0; i < numFields; i++ {
+				fieldValue, ok := getFieldByPath(rv, c.indexes[i])
+				if shouldOmitByParent(rv, c.omitPaths[i]) || !ok {
+					fieldValue = reflect.Value{}
+				}
+				size, err := e.calcSize(fieldValue)
+				if err != nil {
+					return 0, err
+				}
+				ret += size
 			}
-			ret += size
 		}
 	} else {
 		numFields = len(c.simpleIndexes)
-		for i := 0; i < numFields; i++ {
-			size, err := e.calcSize(rv.Field(c.simpleIndexes[i]))
-			if err != nil {
-				return 0, err
+		if noCustom {
+			for i := 0; i < numFields; i++ {
+				size, err := e.calcSizeBuiltIn(rv.Field(c.simpleIndexes[i]))
+				if err != nil {
+					return 0, err
+				}
+				ret += size
 			}
-			ret += size
+		} else {
+			for i := 0; i < numFields; i++ {
+				size, err := e.calcSize(rv.Field(c.simpleIndexes[i]))
+				if err != nil {
+					return 0, err
+				}
+				ret += size
+			}
 		}
 	}
 
@@ -204,32 +218,63 @@ func (e *encoder) calcStructMap(rv reflect.Value) (int, error) {
 	} else {
 		c = cache.(*structCache)
 	}
+	noCustom := e.extRegistry.customCount == 0
 
 	l := 0
 	if c.hasEmbedded {
-		for i := 0; i < len(c.indexes); i++ {
-			fieldValue, ok := getFieldByPath(rv, c.indexes[i])
-			if shouldOmitByParent(rv, c.omitPaths[i]) || !ok {
-				continue
+		if noCustom {
+			for i := 0; i < len(c.indexes); i++ {
+				fieldValue, ok := getFieldByPath(rv, c.indexes[i])
+				if shouldOmitByParent(rv, c.omitPaths[i]) || !ok {
+					continue
+				}
+				size, err := e.calcSizeWithOmitEmptyBuiltIn(fieldValue, c.names[i], c.omits[i])
+				if err != nil {
+					return 0, err
+				}
+				ret += size
+				if size > 0 {
+					l++
+				}
 			}
-			size, err := e.calcSizeWithOmitEmpty(fieldValue, c.names[i], c.omits[i])
-			if err != nil {
-				return 0, err
-			}
-			ret += size
-			if size > 0 {
-				l++
+		} else {
+			for i := 0; i < len(c.indexes); i++ {
+				fieldValue, ok := getFieldByPath(rv, c.indexes[i])
+				if shouldOmitByParent(rv, c.omitPaths[i]) || !ok {
+					continue
+				}
+				size, err := e.calcSizeWithOmitEmpty(fieldValue, c.names[i], c.omits[i])
+				if err != nil {
+					return 0, err
+				}
+				ret += size
+				if size > 0 {
+					l++
+				}
 			}
 		}
 	} else {
-		for i := 0; i < len(c.simpleIndexes); i++ {
-			size, err := e.calcSizeWithOmitEmpty(rv.Field(c.simpleIndexes[i]), c.names[i], c.omits[i])
-			if err != nil {
-				return 0, err
+		if noCustom {
+			for i := 0; i < len(c.simpleIndexes); i++ {
+				size, err := e.calcSizeWithOmitEmptyBuiltIn(rv.Field(c.simpleIndexes[i]), c.names[i], c.omits[i])
+				if err != nil {
+					return 0, err
+				}
+				ret += size
+				if size > 0 {
+					l++
+				}
 			}
-			ret += size
-			if size > 0 {
-				l++
+		} else {
+			for i := 0; i < len(c.simpleIndexes); i++ {
+				size, err := e.calcSizeWithOmitEmpty(rv.Field(c.simpleIndexes[i]), c.names[i], c.omits[i])
+				if err != nil {
+					return 0, err
+				}
+				ret += size
+				if size > 0 {
+					l++
+				}
 			}
 		}
 	}
@@ -257,15 +302,21 @@ func (e *encoder) calcSizeWithOmitEmpty(rv reflect.Value, name string, omit bool
 	return keySize + valueSize, nil
 }
 
-func (e *encoder) getStructWriter(typ reflect.Type) structWriteFunc {
-	for i := range extCoders {
-		if extCoders[i].Type() == typ {
-			return func(rv reflect.Value, offset int) int {
-				return extCoders[i].WriteToBytes(rv, offset, &e.d)
-			}
+func (e *encoder) calcSizeWithOmitEmptyBuiltIn(rv reflect.Value, name string, omit bool) (int, error) {
+	keySize := 0
+	valueSize := 0
+	if !omit || !rv.IsZero() {
+		keySize = e.calcString(name)
+		vSize, err := e.calcSizeBuiltIn(rv)
+		if err != nil {
+			return 0, err
 		}
+		valueSize = vSize
 	}
+	return keySize + valueSize, nil
+}
 
+func (e *encoder) getStructWriter(_ reflect.Type) structWriteFunc {
 	if e.asArray {
 		return e.writeStructArray
 	}
@@ -278,12 +329,6 @@ func (e *encoder) writeStruct(rv reflect.Value, offset int) int {
 			return e.writeTime(tm, offset)
 		}
 	*/
-
-	for i := range extCoders {
-		if extCoders[i].Type() == rv.Type() {
-			return extCoders[i].WriteToBytes(rv, offset, &e.d)
-		}
-	}
 
 	if e.asArray {
 		return e.writeStructArray(rv, offset)
@@ -312,6 +357,7 @@ func (e *encoder) writeStructArray(rv reflect.Value, offset int) int {
 		offset = e.setByte1Int(def.Array32, offset)
 		offset = e.setByte4Int(num, offset)
 	}
+	noCustom := e.extRegistry.customCount == 0
 
 	if c.hasEmbedded {
 		for i := 0; i < num; i++ {
@@ -319,11 +365,21 @@ func (e *encoder) writeStructArray(rv reflect.Value, offset int) int {
 			if shouldOmitByParent(rv, c.omitPaths[i]) || !ok {
 				fieldValue = reflect.Value{}
 			}
-			offset = e.create(fieldValue, offset)
+			if noCustom {
+				offset = e.createBuiltIn(fieldValue, offset)
+			} else {
+				offset = e.create(fieldValue, offset)
+			}
 		}
 	} else {
-		for i := 0; i < num; i++ {
-			offset = e.create(rv.Field(c.simpleIndexes[i]), offset)
+		if noCustom {
+			for i := 0; i < num; i++ {
+				offset = e.createBuiltIn(rv.Field(c.simpleIndexes[i]), offset)
+			}
+		} else {
+			for i := 0; i < num; i++ {
+				offset = e.create(rv.Field(c.simpleIndexes[i]), offset)
+			}
 		}
 	}
 	return offset
@@ -364,6 +420,7 @@ func (e *encoder) writeStructMap(rv reflect.Value, offset int) int {
 		offset = e.setByte1Int(def.Map32, offset)
 		offset = e.setByte4Int(l, offset)
 	}
+	noCustom := e.extRegistry.customCount == 0
 
 	if c.hasEmbedded {
 		num := len(c.indexes)
@@ -374,16 +431,30 @@ func (e *encoder) writeStructMap(rv reflect.Value, offset int) int {
 			}
 			if c.noOmit || !c.omits[i] || !fieldValue.IsZero() {
 				offset = e.writeString(c.names[i], offset)
-				offset = e.create(fieldValue, offset)
+				if noCustom {
+					offset = e.createBuiltIn(fieldValue, offset)
+				} else {
+					offset = e.create(fieldValue, offset)
+				}
 			}
 		}
 	} else {
 		num := len(c.simpleIndexes)
-		for i := 0; i < num; i++ {
-			fieldValue := rv.Field(c.simpleIndexes[i])
-			if c.noOmit || !c.omits[i] || !fieldValue.IsZero() {
-				offset = e.writeString(c.names[i], offset)
-				offset = e.create(fieldValue, offset)
+		if noCustom {
+			for i := 0; i < num; i++ {
+				fieldValue := rv.Field(c.simpleIndexes[i])
+				if c.noOmit || !c.omits[i] || !fieldValue.IsZero() {
+					offset = e.writeString(c.names[i], offset)
+					offset = e.createBuiltIn(fieldValue, offset)
+				}
+			}
+		} else {
+			for i := 0; i < num; i++ {
+				fieldValue := rv.Field(c.simpleIndexes[i])
+				if c.noOmit || !c.omits[i] || !fieldValue.IsZero() {
+					offset = e.writeString(c.names[i], offset)
+					offset = e.create(fieldValue, offset)
+				}
 			}
 		}
 	}

--- a/internal/encoding/struct_test.go
+++ b/internal/encoding/struct_test.go
@@ -16,14 +16,14 @@ func Test_calcStructArray(t *testing.T) {
 
 	t.Run("non-cache", func(t *testing.T) {
 		value := b{B: make([]byte, math.MaxUint32+1)}
-		e := encoder{}
+		e := encoder{extRegistry: currentExtEncoderRegistry.Load()}
 		rv := reflect.ValueOf(value)
 		_, err := e.calcStructArray(rv)
 		tu.IsError(t, err, def.ErrUnsupportedType)
 	})
 	t.Run("cache", func(t *testing.T) {
 		value := b{B: make([]byte, 1)}
-		e := encoder{}
+		e := encoder{extRegistry: currentExtEncoderRegistry.Load()}
 		rv := reflect.ValueOf(value)
 		_, err := e.calcStructArray(rv)
 		tu.NoError(t, err)
@@ -64,7 +64,7 @@ func Test_calcStructArray(t *testing.T) {
 	}
 	for _, tc := range testcases {
 		t.Run(tc.name, func(t *testing.T) {
-			e := encoder{}
+			e := encoder{extRegistry: currentExtEncoderRegistry.Load()}
 			v, _, bs := tu.CreateStruct(tc.value)
 			rv := reflect.ValueOf(v).Elem()
 			result, err := e.calcStructArray(rv)
@@ -81,14 +81,14 @@ func Test_calcStructMap(t *testing.T) {
 
 	t.Run("non-cache", func(t *testing.T) {
 		value := b{B: make([]byte, math.MaxUint32+1)}
-		e := encoder{}
+		e := encoder{extRegistry: currentExtEncoderRegistry.Load()}
 		rv := reflect.ValueOf(value)
 		_, err := e.calcStructMap(rv)
 		tu.IsError(t, err, def.ErrUnsupportedType)
 	})
 	t.Run("cache", func(t *testing.T) {
 		value := b{B: make([]byte, 1)}
-		e := encoder{}
+		e := encoder{extRegistry: currentExtEncoderRegistry.Load()}
 		rv := reflect.ValueOf(value)
 		_, err := e.calcStructMap(rv)
 		tu.NoError(t, err)
@@ -129,7 +129,7 @@ func Test_calcStructMap(t *testing.T) {
 	}
 	for _, tc := range testcases {
 		t.Run(tc.name, func(t *testing.T) {
-			e := encoder{}
+			e := encoder{extRegistry: currentExtEncoderRegistry.Load()}
 			v, bs, _ := tu.CreateStruct(tc.value)
 			rv := reflect.ValueOf(v).Elem()
 			result, err := e.calcStructMap(rv)
@@ -163,7 +163,7 @@ func Test_writeStructArray(t *testing.T) {
 	}
 	for _, tc := range testcases {
 		t.Run(tc.name, func(t *testing.T) {
-			e := encoder{}
+			e := encoder{extRegistry: currentExtEncoderRegistry.Load()}
 			v, _, _ := tu.CreateStruct(tc.value)
 			rv := reflect.ValueOf(v).Elem()
 			size, err := e.calcStructArray(rv)
@@ -201,7 +201,7 @@ func Test_writeStructMap(t *testing.T) {
 	}
 	for _, tc := range testcases {
 		t.Run(tc.name, func(t *testing.T) {
-			e := encoder{}
+			e := encoder{extRegistry: currentExtEncoderRegistry.Load()}
 			v, _, _ := tu.CreateStruct(tc.value)
 			rv := reflect.ValueOf(v).Elem()
 			size, err := e.calcStructMap(rv)
@@ -216,7 +216,7 @@ func Test_writeStructMap(t *testing.T) {
 }
 
 func Test_calcSizeWithOmitEmpty(t *testing.T) {
-	e := encoder{}
+	e := encoder{extRegistry: currentExtEncoderRegistry.Load()}
 	var v any
 	v = func() {}
 	_, err := e.calcSizeWithOmitEmpty(reflect.ValueOf(v), "a", false)
@@ -249,7 +249,7 @@ func Test_structCache(t *testing.T) {
 		Str  string
 	}
 
-	e := encoder{}
+	e := encoder{extRegistry: currentExtEncoderRegistry.Load()}
 	testcases := []struct {
 		v         any
 		omitCount int

--- a/internal/stream/decoding/decoding.go
+++ b/internal/stream/decoding/decoding.go
@@ -50,6 +50,16 @@ func (d *decoder) decode(rv reflect.Value) error {
 
 func (d *decoder) decodeWithCode(code byte, rv reflect.Value) error {
 	k := rv.Kind()
+
+	// ext types: honor a registered ext decoder for any destination kind, not
+	// just structs (mirrors setStruct). Falls through to the kind switch when
+	// nothing matches, e.g. because no ext coder claims the bytes.
+	if ok, err := d.tryExtDecode(code, rv, k); err != nil {
+		return err
+	} else if ok {
+		return nil
+	}
+
 	switch k {
 	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
 		v, err := d.asIntWithCode(code, k)

--- a/internal/stream/decoding/defined_type_ext_test.go
+++ b/internal/stream/decoding/defined_type_ext_test.go
@@ -1,0 +1,98 @@
+package decoding
+
+import (
+	"bytes"
+	"reflect"
+	"testing"
+
+	"github.com/shamaton/msgpack/v3/def"
+	"github.com/shamaton/msgpack/v3/ext"
+	"github.com/shamaton/msgpack/v3/internal/common"
+	tu "github.com/shamaton/msgpack/v3/internal/common/testutil"
+)
+
+// issue55Status/issue55Statuses mirror the non-stream decode fixtures: named
+// non-struct types, as commonly used for Go "enums", that must round-trip
+// through a registered stream ext decoder.
+type issue55StreamDecStatus int
+
+type issue55StreamDecHolder struct {
+	Status issue55StreamDecStatus
+}
+
+type issue55StreamDecDecoder struct {
+	code int8
+}
+
+func (d *issue55StreamDecDecoder) Code() int8 { return d.code }
+
+func (d *issue55StreamDecDecoder) IsType(code byte, innerType int8, _ int) bool {
+	return code == def.Fixext1 && innerType == d.code
+}
+
+func (d *issue55StreamDecDecoder) ToValue(_ byte, data []byte, _ reflect.Kind) (interface{}, error) {
+	return issue55StreamDecStatus(int8(data[0])), nil
+}
+
+func newTestDecoder(data []byte) decoder {
+	return decoder{r: bytes.NewReader(data), buf: common.GetBuffer()}
+}
+
+func issue55StreamDecBytes(code int8, v issue55StreamDecStatus) []byte {
+	return []byte{def.Fixext1, byte(code), byte(v)}
+}
+
+func Test_StreamDecodeExtCoderForNamedNonStructType(t *testing.T) {
+	dec := &issue55StreamDecDecoder{code: 42}
+	AddExtDecoder(dec)
+	defer RemoveExtDecoder(dec)
+
+	t.Run("top level", func(t *testing.T) {
+		var got issue55StreamDecStatus
+		d := newTestDecoder(issue55StreamDecBytes(42, 7))
+		defer common.PutBuffer(d.buf)
+		err := d.decode(reflect.ValueOf(&got).Elem())
+		tu.NoError(t, err)
+		tu.Equal(t, got, issue55StreamDecStatus(7))
+	})
+
+	t.Run("slice element", func(t *testing.T) {
+		data := append([]byte{def.FixArray + 2}, issue55StreamDecBytes(42, 1)...)
+		data = append(data, issue55StreamDecBytes(42, 2)...)
+
+		var got []issue55StreamDecStatus
+		d := newTestDecoder(data)
+		defer common.PutBuffer(d.buf)
+		err := d.decode(reflect.ValueOf(&got).Elem())
+		tu.NoError(t, err)
+		if !reflect.DeepEqual(got, []issue55StreamDecStatus{1, 2}) {
+			t.Fatalf("got %v", got)
+		}
+	})
+
+	t.Run("struct field via map", func(t *testing.T) {
+		data := append([]byte{def.FixMap + 1, def.FixStr + byte(len("Status"))}, "Status"...)
+		data = append(data, issue55StreamDecBytes(42, 9)...)
+
+		var got issue55StreamDecHolder
+		d := newTestDecoder(data)
+		d.asArray = false
+		defer common.PutBuffer(d.buf)
+		err := d.decode(reflect.ValueOf(&got).Elem())
+		tu.NoError(t, err)
+		tu.Equal(t, got.Status, issue55StreamDecStatus(9))
+	})
+
+	t.Run("no match falls back to kind switch", func(t *testing.T) {
+		// A registered decoder whose IsType never matches must not prevent an
+		// ordinary (non-ext) value of the same underlying kind from decoding.
+		var got issue55StreamDecStatus
+		d := newTestDecoder([]byte{0x05}) // fixint 5, not an ext frame
+		defer common.PutBuffer(d.buf)
+		err := d.decode(reflect.ValueOf(&got).Elem())
+		tu.NoError(t, err)
+		tu.Equal(t, got, issue55StreamDecStatus(5))
+	})
+}
+
+var _ = ext.StreamDecoder((*issue55StreamDecDecoder)(nil))

--- a/internal/stream/decoding/ext.go
+++ b/internal/stream/decoding/ext.go
@@ -2,6 +2,7 @@ package decoding
 
 import (
 	"encoding/binary"
+	"reflect"
 
 	"github.com/shamaton/msgpack/v3/def"
 	"github.com/shamaton/msgpack/v3/ext"
@@ -13,6 +14,50 @@ var (
 	extCoderMap = map[int8]ext.StreamDecoder{time.StreamDecoder.Code(): time.StreamDecoder}
 	extCoders   = []ext.StreamDecoder{time.StreamDecoder}
 )
+
+// tryExtDecode attempts to decode the value using a registered ext decoder
+// whose Go type matches the destination rv, mirroring the dispatch setStruct
+// already performed for struct destinations only. readIfExtType both
+// recognizes the ext wire codes and reads the full frame (header and
+// payload) from the reader, so truncated input surfaces as a read error
+// before any custom decoder callback runs; non-ext codes make it return with
+// data == nil and no error, at the cost of a single already-read code byte.
+// Returns ok=false when no registered decoder claims the bytes, so callers
+// fall back to the normal kind-based decoding (which will surface a clear
+// type-mismatch error).
+func (d *decoder) tryExtDecode(code byte, rv reflect.Value, k reflect.Kind) (bool, error) {
+	if len(extCoders) == 0 {
+		return false, nil
+	}
+	// The only registered decoder is the built-in time.StreamDecoder, which
+	// targets a struct destination; skip the ext read entirely for other
+	// kinds. Use rv.Kind() rather than the passed-in k: callers such as the
+	// slice-of-struct fast path pass the container's kind, not the element's.
+	if len(extCoders) == 1 && rv.Kind() != reflect.Struct {
+		return false, nil
+	}
+	innerType, data, err := d.readIfExtType(code)
+	if err != nil {
+		return false, err
+	}
+	if data == nil {
+		return false, nil
+	}
+	for i := range extCoders {
+		if !extCoders[i].IsType(code, innerType, len(data)) {
+			continue
+		}
+		v, err := extCoders[i].ToValue(code, data, k)
+		if err != nil {
+			return false, err
+		}
+		if rv.Type() == reflect.TypeOf(v) {
+			rv.Set(reflect.ValueOf(v))
+			return true, nil
+		}
+	}
+	return false, nil
+}
 
 // AddExtDecoder adds decoders for extension types.
 func AddExtDecoder(f ext.StreamDecoder) {

--- a/internal/stream/decoding/struct.go
+++ b/internal/stream/decoding/struct.go
@@ -60,27 +60,10 @@ func getFieldByPath(rv reflect.Value, path []int, allowAlloc bool) (reflect.Valu
 }
 
 func (d *decoder) setStruct(code byte, rv reflect.Value, k reflect.Kind) error {
-	if len(extCoders) > 0 {
-		innerType, data, err := d.readIfExtType(code)
-		if err != nil {
-			return err
-		}
-		if data != nil {
-			for i := range extCoders {
-				if extCoders[i].IsType(code, innerType, len(data)) {
-					v, err := extCoders[i].ToValue(code, data, k)
-					if err != nil {
-						return err
-					}
-
-					// Validate that the receptacle is of the right value type.
-					if rv.Type() == reflect.TypeOf(v) {
-						rv.Set(reflect.ValueOf(v))
-						return nil
-					}
-				}
-			}
-		}
+	if ok, err := d.tryExtDecode(code, rv, k); err != nil {
+		return err
+	} else if ok {
+		return nil
 	}
 
 	if d.asArray {

--- a/internal/stream/encoding/benchmark_test.go
+++ b/internal/stream/encoding/benchmark_test.go
@@ -1,0 +1,147 @@
+package encoding
+
+import (
+	"bytes"
+	"reflect"
+	"testing"
+	stdtime "time"
+
+	"github.com/shamaton/msgpack/v3/def"
+	"github.com/shamaton/msgpack/v3/ext"
+)
+
+type benchmarkStatus int
+type benchmarkStatuses []benchmarkStatus
+
+type benchmarkStruct struct {
+	ID     int64
+	Name   string
+	Active bool
+	Score  float64
+	Tags   []string
+	Data   []byte
+}
+
+type benchmarkIndirect struct {
+	Pointer   *int
+	Interface any
+	Values    []any
+	Nested    [][]int
+}
+
+var (
+	benchmarkStreamLength int
+	benchmarkPointerInt   = 42
+	benchmarkIntSlice     = makeBenchmarkInts()
+	benchmarkStatusSlice  = makeBenchmarkStatuses()
+	benchmarkStructValue  = benchmarkStruct{
+		ID: 42, Name: "benchmark", Active: true, Score: 12.5,
+		Tags: []string{"a", "b", "c", "d"}, Data: make([]byte, 64),
+	}
+	benchmarkTimeValue     = stdtime.Unix(1_700_000_000, 123_456_789)
+	benchmarkIndirectValue = benchmarkIndirect{
+		Pointer:   &benchmarkPointerInt,
+		Interface: int(42),
+		Values:    []any{int(1), "two", []int{3, 4}},
+		Nested:    [][]int{{1, 2}, {3, 4}},
+	}
+)
+
+func makeBenchmarkInts() []int {
+	values := make([]int, 1024)
+	for i := range values {
+		values[i] = i % 128
+	}
+	return values
+}
+
+func makeBenchmarkStatuses() []benchmarkStatus {
+	values := make([]benchmarkStatus, 1024)
+	for i := range values {
+		values[i] = benchmarkStatus(i % 128)
+	}
+	return values
+}
+
+type benchmarkExtEncoder struct {
+	typ reflect.Type
+}
+
+func (e *benchmarkExtEncoder) Code() int8         { return 42 }
+func (e *benchmarkExtEncoder) Type() reflect.Type { return e.typ }
+func (e *benchmarkExtEncoder) Write(w ext.StreamWriter, value reflect.Value) error {
+	if err := w.WriteByte1Int(def.Fixext1); err != nil {
+		return err
+	}
+	if err := w.WriteByte1Int(int(e.Code())); err != nil {
+		return err
+	}
+	return w.WriteByte1Int64(valueToInt64(value))
+}
+
+func valueToInt64(value reflect.Value) int64 {
+	if value.Kind() == reflect.Slice {
+		return int64(value.Len())
+	}
+	return value.Int()
+}
+
+func benchmarkStreamEncode(b *testing.B, value any) {
+	b.Helper()
+	var buffer bytes.Buffer
+	if err := Encode(&buffer, value, false); err != nil {
+		b.Fatal(err)
+	}
+	b.ReportAllocs()
+	b.ResetTimer()
+	for b.Loop() {
+		buffer.Reset()
+		if err := Encode(&buffer, value, false); err != nil {
+			b.Fatal(err)
+		}
+		benchmarkStreamLength = buffer.Len()
+	}
+	b.StopTimer()
+}
+
+func benchmarkStreamEncodeExt(b *testing.B, value any, encoder *benchmarkExtEncoder) {
+	b.Helper()
+	AddExtEncoder(encoder)
+	defer RemoveExtEncoder(encoder)
+	benchmarkStreamEncode(b, value)
+}
+
+func BenchmarkStreamEncodeInt(b *testing.B) {
+	benchmarkStreamEncode(b, int(42))
+}
+
+func BenchmarkStreamEncodeIntSlice(b *testing.B) {
+	benchmarkStreamEncode(b, benchmarkIntSlice)
+}
+
+func BenchmarkStreamEncodeStruct(b *testing.B) {
+	benchmarkStreamEncode(b, benchmarkStructValue)
+}
+
+func BenchmarkStreamEncodeTime(b *testing.B) {
+	benchmarkStreamEncode(b, benchmarkTimeValue)
+}
+
+func BenchmarkStreamEncodeIndirect(b *testing.B) {
+	benchmarkStreamEncode(b, benchmarkIndirectValue)
+}
+
+func BenchmarkStreamEncodeStatus(b *testing.B) {
+	encoder := &benchmarkExtEncoder{typ: reflect.TypeOf(benchmarkStatus(0))}
+	benchmarkStreamEncodeExt(b, benchmarkStatus(42), encoder)
+}
+
+func BenchmarkStreamEncodeStatusSlice(b *testing.B) {
+	encoder := &benchmarkExtEncoder{typ: reflect.TypeOf(benchmarkStatus(0))}
+	benchmarkStreamEncodeExt(b, benchmarkStatusSlice, encoder)
+}
+
+func BenchmarkStreamEncodeStatuses(b *testing.B) {
+	encoder := &benchmarkExtEncoder{typ: reflect.TypeOf(benchmarkStatuses{})}
+	benchmarkStreamEncodeExt(b, benchmarkStatuses(benchmarkStatusSlice), encoder)
+}

--- a/internal/stream/encoding/defined_type_ext_test.go
+++ b/internal/stream/encoding/defined_type_ext_test.go
@@ -1,0 +1,287 @@
+package encoding
+
+import (
+	"bytes"
+	"reflect"
+	"sync"
+	"testing"
+
+	"github.com/shamaton/msgpack/v3/def"
+	"github.com/shamaton/msgpack/v3/ext"
+	tu "github.com/shamaton/msgpack/v3/internal/common/testutil"
+)
+
+type issue55Status int
+type issue55OtherStatus int
+type issue55Statuses []issue55Status
+type issue55Bytes []byte
+
+type issue55Holder struct {
+	Status issue55Status
+	Value  any
+}
+
+type issue55ExtEncoder struct {
+	typ       reflect.Type
+	code      int8
+	marker    byte
+	sawNil    bool
+	writeCall int
+}
+
+func (e *issue55ExtEncoder) Code() int8         { return e.code }
+func (e *issue55ExtEncoder) Type() reflect.Type { return e.typ }
+func (e *issue55ExtEncoder) Write(w ext.StreamWriter, value reflect.Value) error {
+	if isNilValue(value) {
+		e.sawNil = true
+	}
+	e.writeCall++
+	if err := w.WriteByte1Int(def.Fixext1); err != nil {
+		return err
+	}
+	if err := w.WriteByte1Int(int(e.code)); err != nil {
+		return err
+	}
+	return w.WriteByte1Uint64(uint64(e.marker))
+}
+
+func isNilValue(value reflect.Value) bool {
+	switch value.Kind() {
+	case reflect.Chan, reflect.Func, reflect.Interface, reflect.Map, reflect.Ptr, reflect.Slice:
+		return value.IsNil()
+	default:
+		return false
+	}
+}
+
+func issue55ExtBytes(code int8, marker byte) []byte {
+	return []byte{def.Fixext1, byte(code), marker}
+}
+
+func addIssue55Encoder(t *testing.T, typ reflect.Type, code int8, marker byte) *issue55ExtEncoder {
+	t.Helper()
+	encoder := &issue55ExtEncoder{typ: typ, code: code, marker: marker}
+	AddExtEncoder(encoder)
+	t.Cleanup(func() { RemoveExtEncoder(encoder) })
+	return encoder
+}
+
+func encodeIssue55(t *testing.T, value any) []byte {
+	t.Helper()
+	var buffer bytes.Buffer
+	tu.NoError(t, Encode(&buffer, value, false))
+	return buffer.Bytes()
+}
+
+func TestDefinedTypeExtEncoderSelection(t *testing.T) {
+	statusEncoder := addIssue55Encoder(t, reflect.TypeOf(issue55Status(0)), 21, 0xa1)
+	extStatus := issue55ExtBytes(statusEncoder.code, statusEncoder.marker)
+
+	t.Run("root", func(t *testing.T) {
+		tu.EqualSlice(t, encodeIssue55(t, issue55Status(1)), extStatus)
+	})
+
+	t.Run("struct field", func(t *testing.T) {
+		expected := append([]byte{def.FixArray + 2}, extStatus...)
+		expected = append(expected, def.Nil)
+		var buffer bytes.Buffer
+		tu.NoError(t, Encode(&buffer, issue55Holder{Status: 1}, true))
+		tu.EqualSlice(t, buffer.Bytes(), expected)
+	})
+
+	t.Run("interface field", func(t *testing.T) {
+		expected := append([]byte{def.FixArray + 2}, extStatus...)
+		expected = append(expected, extStatus...)
+		var buffer bytes.Buffer
+		tu.NoError(t, Encode(&buffer, issue55Holder{Value: issue55Status(1)}, true))
+		tu.EqualSlice(t, buffer.Bytes(), expected)
+	})
+
+	t.Run("map key and value", func(t *testing.T) {
+		expected := append([]byte{def.FixMap + 1}, extStatus...)
+		expected = append(expected, extStatus...)
+		tu.EqualSlice(t, encodeIssue55(t, map[issue55Status]issue55Status{1: 2}), expected)
+	})
+
+	t.Run("slice elements", func(t *testing.T) {
+		expected := append([]byte{def.FixArray + 2}, extStatus...)
+		expected = append(expected, extStatus...)
+		tu.EqualSlice(t, encodeIssue55(t, []issue55Status{1, 2}), expected)
+	})
+}
+
+func TestDefinedTypeWholeContainerExtTakesPrecedence(t *testing.T) {
+	statusEncoder := addIssue55Encoder(t, reflect.TypeOf(issue55Status(0)), 22, 0xb1)
+	statusesEncoder := addIssue55Encoder(t, reflect.TypeOf(issue55Statuses{}), 23, 0xb2)
+
+	encoded := encodeIssue55(t, issue55Statuses{1, 2})
+	tu.EqualSlice(t, encoded, issue55ExtBytes(statusesEncoder.code, statusesEncoder.marker))
+	tu.Equal(t, statusEncoder.writeCall, 0)
+}
+
+func TestDefinedTypeExtBypassesContainerFastPaths(t *testing.T) {
+	t.Run("defined byte slice", func(t *testing.T) {
+		encoder := addIssue55Encoder(t, reflect.TypeOf(issue55Bytes{}), 24, 0xc1)
+		tu.EqualSlice(t, encodeIssue55(t, issue55Bytes{1, 2}), issue55ExtBytes(encoder.code, encoder.marker))
+	})
+
+	t.Run("byte elements", func(t *testing.T) {
+		encoder := addIssue55Encoder(t, reflect.TypeOf(byte(0)), 25, 0xc2)
+		extByte := issue55ExtBytes(encoder.code, encoder.marker)
+		for _, value := range []any{[]byte{1, 2}, [2]byte{1, 2}} {
+			expected := append([]byte{def.FixArray + 2}, extByte...)
+			expected = append(expected, extByte...)
+			tu.EqualSlice(t, encodeIssue55(t, value), expected)
+		}
+	})
+
+	t.Run("fixed slice", func(t *testing.T) {
+		encoder := addIssue55Encoder(t, reflect.TypeOf(int(0)), 26, 0xc3)
+		extInt := issue55ExtBytes(encoder.code, encoder.marker)
+		expected := append([]byte{def.FixArray + 2}, extInt...)
+		expected = append(expected, extInt...)
+		tu.EqualSlice(t, encodeIssue55(t, []int{1, 2}), expected)
+	})
+
+	t.Run("fixed map", func(t *testing.T) {
+		stringEncoder := addIssue55Encoder(t, reflect.TypeOf(""), 27, 0xc4)
+		intEncoder := addIssue55Encoder(t, reflect.TypeOf(int(0)), 28, 0xc5)
+		expected := append([]byte{def.FixMap + 1}, issue55ExtBytes(stringEncoder.code, stringEncoder.marker)...)
+		expected = append(expected, issue55ExtBytes(intEncoder.code, intEncoder.marker)...)
+		tu.EqualSlice(t, encodeIssue55(t, map[string]int{"key": 1}), expected)
+	})
+}
+
+func TestDefinedTypeExtNilAndRemovalSemantics(t *testing.T) {
+	t.Run("nil registered values", func(t *testing.T) {
+		sliceEncoder := addIssue55Encoder(t, reflect.TypeOf(issue55Statuses(nil)), 29, 0xd1)
+		pointerEncoder := addIssue55Encoder(t, reflect.TypeOf((*issue55Status)(nil)), 30, 0xd2)
+
+		tu.EqualSlice(t, encodeIssue55(t, issue55Statuses(nil)), issue55ExtBytes(sliceEncoder.code, sliceEncoder.marker))
+		tu.Equal(t, sliceEncoder.sawNil, true)
+		tu.EqualSlice(t, encodeIssue55(t, (*issue55Status)(nil)), issue55ExtBytes(pointerEncoder.code, pointerEncoder.marker))
+		tu.Equal(t, pointerEncoder.sawNil, true)
+	})
+
+	t.Run("remove restores built-in", func(t *testing.T) {
+		encoder := &issue55ExtEncoder{typ: reflect.TypeOf(issue55Status(0)), code: 31, marker: 0xd3}
+		AddExtEncoder(encoder)
+		RemoveExtEncoder(encoder)
+		tu.EqualSlice(t, encodeIssue55(t, issue55Status(1)), []byte{1})
+	})
+
+	t.Run("first registration wins", func(t *testing.T) {
+		first := addIssue55Encoder(t, reflect.TypeOf(issue55Status(0)), 32, 0xd4)
+		second := &issue55ExtEncoder{typ: first.typ, code: 33, marker: 0xd5}
+		AddExtEncoder(second)
+		tu.EqualSlice(t, encodeIssue55(t, issue55Status(1)), issue55ExtBytes(first.code, first.marker))
+	})
+}
+
+func TestExtEncoderRegistryCopyOnWrite(t *testing.T) {
+	typ := reflect.TypeOf(issue55Status(0))
+	before := currentExtEncoderRegistry.Load()
+	encoder := &issue55ExtEncoder{typ: typ, code: 34, marker: 0xe1}
+
+	AddExtEncoder(encoder)
+	afterAdd := currentExtEncoderRegistry.Load()
+	if before == afterAdd {
+		t.Fatal("registration must publish a new registry snapshot")
+	}
+	if before.byKind[reflect.Int] != nil {
+		t.Fatal("published old snapshot was mutated")
+	}
+	if afterAdd.byKind[reflect.Int][typ] != encoder {
+		t.Fatal("new snapshot does not contain encoder")
+	}
+	if afterAdd.customCount != before.customCount+1 || !afterAdd.hasCustom[reflect.Int] {
+		t.Fatal("new snapshot does not enable the custom kind fast-path flag")
+	}
+
+	RemoveExtEncoder(encoder)
+	afterRemove := currentExtEncoderRegistry.Load()
+	if afterAdd.byKind[reflect.Int][typ] != encoder {
+		t.Fatal("published added snapshot was mutated")
+	}
+	if afterRemove.byKind[reflect.Int] != nil {
+		t.Fatal("last removal must restore nil kind bucket")
+	}
+	if afterRemove.customCount != before.customCount || afterRemove.hasCustom[reflect.Int] {
+		t.Fatal("last removal must restore the no-custom fast path")
+	}
+}
+
+func TestExtEncoderRegistryKeepsKindFlagAfterPartialRemoval(t *testing.T) {
+	first := &issue55ExtEncoder{typ: reflect.TypeOf(issue55Status(0)), code: 37, marker: 0xf3}
+	second := &issue55ExtEncoder{typ: reflect.TypeOf(issue55OtherStatus(0)), code: 38, marker: 0xf4}
+	AddExtEncoder(first)
+	AddExtEncoder(second)
+	t.Cleanup(func() {
+		RemoveExtEncoder(first)
+		RemoveExtEncoder(second)
+	})
+
+	RemoveExtEncoder(first)
+	registry := currentExtEncoderRegistry.Load()
+	if !registry.hasCustom[reflect.Int] {
+		t.Fatal("partial removal must keep the custom kind flag")
+	}
+	if registry.byKind[reflect.Int][second.typ] != second {
+		t.Fatal("partial removal lost the remaining encoder")
+	}
+	tu.EqualSlice(t, encodeIssue55(t, issue55OtherStatus(1)), issue55ExtBytes(second.code, second.marker))
+}
+
+type issue55BlockingEncoder struct {
+	*issue55ExtEncoder
+	started chan struct{}
+	release chan struct{}
+	once    sync.Once
+}
+
+func (e *issue55BlockingEncoder) Write(w ext.StreamWriter, value reflect.Value) error {
+	e.once.Do(func() {
+		close(e.started)
+		<-e.release
+	})
+	return e.issue55ExtEncoder.Write(w, value)
+}
+
+func TestEncodeUsesSingleExtRegistrySnapshot(t *testing.T) {
+	typ := reflect.TypeOf(issue55Status(0))
+	first := &issue55BlockingEncoder{
+		issue55ExtEncoder: &issue55ExtEncoder{typ: typ, code: 35, marker: 0xf1},
+		started:           make(chan struct{}),
+		release:           make(chan struct{}),
+	}
+	second := &issue55ExtEncoder{typ: typ, code: 36, marker: 0xf2}
+	AddExtEncoder(first)
+
+	type result struct {
+		data []byte
+		err  error
+	}
+	resultCh := make(chan result, 1)
+	go func() {
+		var buffer bytes.Buffer
+		err := Encode(&buffer, []any{issue55Status(1), issue55Status(2)}, false)
+		resultCh <- result{data: buffer.Bytes(), err: err}
+	}()
+
+	<-first.started
+	RemoveExtEncoder(first)
+	AddExtEncoder(second)
+	close(first.release)
+
+	encoded := <-resultCh
+	tu.NoError(t, encoded.err)
+	firstBytes := issue55ExtBytes(first.code, first.marker)
+	expected := append([]byte{def.FixArray + 2}, firstBytes...)
+	expected = append(expected, firstBytes...)
+	tu.EqualSlice(t, encoded.data, expected)
+
+	var next bytes.Buffer
+	tu.NoError(t, Encode(&next, issue55Status(1), false))
+	tu.EqualSlice(t, next.Bytes(), issue55ExtBytes(second.code, second.marker))
+	RemoveExtEncoder(second)
+}

--- a/internal/stream/encoding/encoding.go
+++ b/internal/stream/encoding/encoding.go
@@ -6,33 +6,35 @@ import (
 	"reflect"
 
 	"github.com/shamaton/msgpack/v3/def"
+	"github.com/shamaton/msgpack/v3/ext"
 	"github.com/shamaton/msgpack/v3/internal/common"
 )
 
 type encoder struct {
-	w       io.Writer
-	asArray bool
-	buf     *common.Buffer
+	w           io.Writer
+	asArray     bool
+	buf         *common.Buffer
+	extRegistry *extEncoderRegistry
 	common.Common
 }
 
 // Encode writes MessagePack-encoded byte array of v to writer.
 func Encode(w io.Writer, v any, asArray bool) error {
 	e := encoder{
-		w:       w,
-		buf:     common.GetBuffer(),
-		asArray: asArray,
+		w:           w,
+		buf:         common.GetBuffer(),
+		asArray:     asArray,
+		extRegistry: currentExtEncoderRegistry.Load(),
 	}
 
 	rv := reflect.ValueOf(v)
-	if rv.Kind() == reflect.Ptr {
-		rv = rv.Elem()
-		if rv.Kind() == reflect.Ptr {
-			rv = rv.Elem()
-		}
-	}
 
-	err := e.create(rv)
+	var err error
+	if e.extRegistry.customCount == 0 {
+		err = e.createBuiltIn(rv)
+	} else {
+		err = e.create(rv)
+	}
 	if err == nil {
 		err = e.buf.Flush(e.w)
 	}
@@ -41,7 +43,27 @@ func Encode(w io.Writer, v any, asArray bool) error {
 }
 
 func (e *encoder) create(rv reflect.Value) error {
-	switch rv.Kind() {
+	kind := rv.Kind()
+	if kind == reflect.Invalid {
+		return e.writeNil()
+	}
+	if encoder, ok := e.extEncoderForValue(kind, rv); ok {
+		return e.writeExt(encoder, rv)
+	}
+	return e.createByKind(rv, kind)
+}
+
+func (e *encoder) createDefault(rv reflect.Value) error {
+	return e.createByKind(rv, rv.Kind())
+}
+
+func (e *encoder) writeExt(encoder ext.StreamEncoder, rv reflect.Value) error {
+	w := ext.CreateStreamWriter(e.w, e.buf)
+	return encoder.Write(w, rv)
+}
+
+func (e *encoder) createByKind(rv reflect.Value, kind reflect.Kind) error {
+	switch kind {
 	case reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64, reflect.Uint:
 		v := rv.Uint()
 		return e.writeUint(v)
@@ -73,8 +95,19 @@ func (e *encoder) create(rv reflect.Value) error {
 			return e.writeNil()
 		}
 		l := rv.Len()
+		elementType := rv.Type().Elem()
+		elementKind := elementType.Kind()
+		var elementEncoder ext.StreamEncoder
+		var elementHasExt bool
+		if e.extRegistry.customCount == 0 {
+			if elementKind == reflect.Struct && elementType == builtInTimeType {
+				elementEncoder, elementHasExt = builtInTimeEncoder, true
+			}
+		} else {
+			elementEncoder, elementHasExt = e.extEncoderForType(elementType)
+		}
 		// bin format
-		if e.isByteSlice(rv) {
+		if !elementHasExt && e.isByteSlice(rv) {
 			if err := e.writeByteSliceLength(l); err != nil {
 				return err
 			}
@@ -86,32 +119,49 @@ func (e *encoder) create(rv reflect.Value) error {
 			return err
 		}
 
-		if find, err := e.writeFixedSlice(rv); err != nil {
-			return err
-		} else if find {
+		if !elementHasExt {
+			if find, err := e.writeFixedSlice(rv); err != nil {
+				return err
+			} else if find {
+				return nil
+			}
+		}
+
+		if elementHasExt {
+			for i := 0; i < l; i++ {
+				if err := e.writeExt(elementEncoder, rv.Index(i)); err != nil {
+					return err
+				}
+			}
 			return nil
 		}
-
-		// func
-		elem := rv.Type().Elem()
-		var f structWriteFunc
-		if elem.Kind() == reflect.Struct {
-			f = e.getStructWriter(elem)
-		} else {
-			f = e.create
+		writeElement := e.createDefault
+		if e.extRegistry.customCount == 0 {
+			writeElement = e.createBuiltIn
+		} else if elementKind == reflect.Struct {
+			writeElement = e.getStructWriter(elementType)
 		}
-
-		// objects
 		for i := 0; i < l; i++ {
-			if err := f(rv.Index(i)); err != nil {
+			if err := writeElement(rv.Index(i)); err != nil {
 				return err
 			}
 		}
 
 	case reflect.Array:
 		l := rv.Len()
+		elementType := rv.Type().Elem()
+		elementKind := elementType.Kind()
+		var elementEncoder ext.StreamEncoder
+		var elementHasExt bool
+		if e.extRegistry.customCount == 0 {
+			if elementKind == reflect.Struct && elementType == builtInTimeType {
+				elementEncoder, elementHasExt = builtInTimeEncoder, true
+			}
+		} else {
+			elementEncoder, elementHasExt = e.extEncoderForType(elementType)
+		}
 		// bin format
-		if e.isByteSlice(rv) {
+		if !elementHasExt && e.isByteSlice(rv) {
 			if err := e.writeByteSliceLength(l); err != nil {
 				return err
 			}
@@ -129,18 +179,22 @@ func (e *encoder) create(rv reflect.Value) error {
 			return err
 		}
 
-		// func
-		elem := rv.Type().Elem()
-		var f structWriteFunc
-		if elem.Kind() == reflect.Struct {
-			f = e.getStructWriter(elem)
-		} else {
-			f = e.create
+		if elementHasExt {
+			for i := 0; i < l; i++ {
+				if err := e.writeExt(elementEncoder, rv.Index(i)); err != nil {
+					return err
+				}
+			}
+			return nil
 		}
-
-		// objects
+		writeElement := e.createDefault
+		if e.extRegistry.customCount == 0 {
+			writeElement = e.createBuiltIn
+		} else if elementKind == reflect.Struct {
+			writeElement = e.getStructWriter(elementType)
+		}
 		for i := 0; i < l; i++ {
-			if err := f(rv.Index(i)); err != nil {
+			if err := writeElement(rv.Index(i)); err != nil {
 				return err
 			}
 		}
@@ -155,19 +209,52 @@ func (e *encoder) create(rv reflect.Value) error {
 			return err
 		}
 
-		if find, err := e.writeFixedMap(rv); err != nil {
-			return err
-		} else if find {
-			return nil
+		keyType, valueType := rv.Type().Key(), rv.Type().Elem()
+		var keyEncoder, valueEncoder ext.StreamEncoder
+		var keyHasExt, valueHasExt bool
+		if e.extRegistry.customCount == 0 {
+			if keyType.Kind() == reflect.Struct && keyType == builtInTimeType {
+				keyEncoder, keyHasExt = builtInTimeEncoder, true
+			}
+			if valueType.Kind() == reflect.Struct && valueType == builtInTimeType {
+				valueEncoder, valueHasExt = builtInTimeEncoder, true
+			}
+		} else {
+			keyEncoder, keyHasExt = e.extEncoderForType(keyType)
+			valueEncoder, valueHasExt = e.extEncoderForType(valueType)
+		}
+		if !keyHasExt && !valueHasExt {
+			if find, err := e.writeFixedMap(rv); err != nil {
+				return err
+			} else if find {
+				return nil
+			}
 		}
 
 		// key-value
 		keys := rv.MapKeys()
 		for _, k := range keys {
-			if err := e.create(k); err != nil {
+			if keyHasExt {
+				if err := e.writeExt(keyEncoder, k); err != nil {
+					return err
+				}
+			} else if e.extRegistry.customCount == 0 {
+				if err := e.createBuiltIn(k); err != nil {
+					return err
+				}
+			} else if err := e.createDefault(k); err != nil {
 				return err
 			}
-			if err := e.create(rv.MapIndex(k)); err != nil {
+			value := rv.MapIndex(k)
+			if valueHasExt {
+				if err := e.writeExt(valueEncoder, value); err != nil {
+					return err
+				}
+			} else if e.extRegistry.customCount == 0 {
+				if err := e.createBuiltIn(value); err != nil {
+					return err
+				}
+			} else if err := e.createDefault(value); err != nil {
 				return err
 			}
 		}
@@ -180,15 +267,19 @@ func (e *encoder) create(rv reflect.Value) error {
 			return e.writeNil()
 		}
 
+		if e.extRegistry.customCount == 0 {
+			return e.createBuiltIn(rv.Elem())
+		}
 		return e.create(rv.Elem())
 
 	case reflect.Interface:
+		if e.extRegistry.customCount == 0 {
+			return e.createBuiltIn(rv.Elem())
+		}
 		return e.create(rv.Elem())
 
-	case reflect.Invalid:
-		return e.writeNil()
 	default:
-		return fmt.Errorf("%v is %w type", rv.Kind(), def.ErrUnsupportedType)
+		return fmt.Errorf("%v is %w type", kind, def.ErrUnsupportedType)
 	}
 	return nil
 }

--- a/internal/stream/encoding/encoding_test.go
+++ b/internal/stream/encoding/encoding_test.go
@@ -87,10 +87,11 @@ func (tc *AsXXXTestCase[T]) Run(t *testing.T) {
 		}()
 
 		e := encoder{
-			w:       w,
-			buf:     buf,
-			Common:  common.Common{},
-			asArray: tc.AsArray,
+			w:           w,
+			buf:         buf,
+			Common:      common.Common{},
+			asArray:     tc.AsArray,
+			extRegistry: currentExtEncoderRegistry.Load(),
 		}
 
 		if tc.BufferSize < tc.PreWriteSize {

--- a/internal/stream/encoding/ext.go
+++ b/internal/stream/encoding/ext.go
@@ -2,49 +2,222 @@ package encoding
 
 import (
 	"reflect"
+	"sync"
+	"sync/atomic"
 
 	"github.com/shamaton/msgpack/v3/ext"
 	"github.com/shamaton/msgpack/v3/time"
 )
 
+type extEncoderRegistry struct {
+	byKind      [reflect.UnsafePointer + 1]map[reflect.Type]ext.StreamEncoder
+	hasCustom   [reflect.UnsafePointer + 1]bool
+	customCount int
+}
+
 var (
-	extCoderMap = map[reflect.Type]ext.StreamEncoder{time.StreamEncoder.Type(): time.StreamEncoder}
-	extCoders   = []ext.StreamEncoder{time.StreamEncoder}
+	extEncoderRegistryMu      sync.Mutex
+	currentExtEncoderRegistry atomic.Pointer[extEncoderRegistry]
+	builtInTimeEncoder        = time.StreamEncoder
+	builtInTimeType           = builtInTimeEncoder.Type()
 )
 
-// AddExtEncoder adds encoders for extension types.
-func AddExtEncoder(f ext.StreamEncoder) {
-	// ignore time
-	if f.Type() == time.Encoder.Type() {
+func init() {
+	registry := &extEncoderRegistry{}
+	registry.byKind[reflect.Struct] = map[reflect.Type]ext.StreamEncoder{
+		builtInTimeType: builtInTimeEncoder,
+	}
+	currentExtEncoderRegistry.Store(registry)
+}
+
+// AddExtEncoder adds an encoder for an exact type without replacing an existing encoder.
+func AddExtEncoder(encoder ext.StreamEncoder) {
+	typ := encoder.Type()
+	if typ == builtInTimeType {
 		return
 	}
 
-	_, ok := extCoderMap[f.Type()]
-	if !ok {
-		extCoderMap[f.Type()] = f
-		updateExtCoders()
-	}
-}
+	extEncoderRegistryMu.Lock()
+	defer extEncoderRegistryMu.Unlock()
 
-// RemoveExtEncoder removes encoders for extension types.
-func RemoveExtEncoder(f ext.StreamEncoder) {
-	// ignore time
-	if f.Type() == time.Encoder.Type() {
+	current := currentExtEncoderRegistry.Load()
+	kind := typ.Kind()
+	if _, exists := current.byKind[kind][typ]; exists {
 		return
 	}
 
-	_, ok := extCoderMap[f.Type()]
-	if ok {
-		delete(extCoderMap, f.Type())
-		updateExtCoders()
+	next := *current
+	next.byKind[kind] = cloneExtEncoderMap(current.byKind[kind], 1)
+	next.byKind[kind][typ] = encoder
+	next.hasCustom[kind] = true
+	next.customCount++
+	currentExtEncoderRegistry.Store(&next)
+}
+
+// RemoveExtEncoder removes the encoder registered for the encoder's exact type.
+func RemoveExtEncoder(encoder ext.StreamEncoder) {
+	typ := encoder.Type()
+	if typ == builtInTimeType {
+		return
+	}
+
+	extEncoderRegistryMu.Lock()
+	defer extEncoderRegistryMu.Unlock()
+
+	current := currentExtEncoderRegistry.Load()
+	kind := typ.Kind()
+	currentKind := current.byKind[kind]
+	if _, exists := currentKind[typ]; !exists {
+		return
+	}
+
+	next := *current
+	if len(currentKind) == 1 {
+		next.byKind[kind] = nil
+		next.hasCustom[kind] = false
+	} else {
+		next.byKind[kind] = cloneExtEncoderMap(currentKind, 0)
+		delete(next.byKind[kind], typ)
+		next.hasCustom[kind] = kind != reflect.Struct || len(next.byKind[kind]) > 1
+	}
+	next.customCount--
+	currentExtEncoderRegistry.Store(&next)
+}
+
+func cloneExtEncoderMap(source map[reflect.Type]ext.StreamEncoder, extraCapacity int) map[reflect.Type]ext.StreamEncoder {
+	cloned := make(map[reflect.Type]ext.StreamEncoder, len(source)+extraCapacity)
+	for typ, encoder := range source {
+		cloned[typ] = encoder
+	}
+	return cloned
+}
+
+func (e *encoder) extEncoderForValue(kind reflect.Kind, value reflect.Value) (ext.StreamEncoder, bool) {
+	if e.extRegistry.customCount == 0 {
+		if kind == reflect.Struct && value.Type() == builtInTimeType {
+			return builtInTimeEncoder, true
+		}
+		return nil, false
+	}
+	if kind == reflect.Struct && !e.extRegistry.hasCustom[reflect.Struct] {
+		if value.Type() == builtInTimeType {
+			return builtInTimeEncoder, true
+		}
+		return nil, false
+	}
+	coders := e.extRegistry.byKind[kind]
+	if coders == nil {
+		return nil, false
+	}
+	encoder, ok := coders[value.Type()]
+	return encoder, ok
+}
+
+func (e *encoder) extEncoderForType(typ reflect.Type) (ext.StreamEncoder, bool) {
+	kind := typ.Kind()
+	if e.extRegistry.customCount == 0 {
+		if kind == reflect.Struct && typ == builtInTimeType {
+			return builtInTimeEncoder, true
+		}
+		return nil, false
+	}
+	if kind == reflect.Struct && !e.extRegistry.hasCustom[reflect.Struct] {
+		if typ == builtInTimeType {
+			return builtInTimeEncoder, true
+		}
+		return nil, false
+	}
+	coders := e.extRegistry.byKind[kind]
+	if coders == nil {
+		return nil, false
+	}
+	encoder, ok := coders[typ]
+	return encoder, ok
+}
+
+func (e *encoder) createBuiltIn(rv reflect.Value) error {
+	kind := rv.Kind()
+	switch kind {
+	case reflect.Invalid:
+		return e.writeNil()
+	case reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64, reflect.Uint:
+		return e.writeUint(rv.Uint())
+	case reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64, reflect.Int:
+		return e.writeInt(rv.Int())
+	case reflect.Float32:
+		return e.writeFloat32(rv.Float())
+	case reflect.Float64:
+		return e.writeFloat64(rv.Float())
+	case reflect.Bool:
+		return e.writeBool(rv.Bool())
+	case reflect.String:
+		return e.writeString(rv.String())
+	case reflect.Complex64:
+		return e.writeComplex64(complex64(rv.Complex()))
+	case reflect.Complex128:
+		return e.writeComplex128(rv.Complex())
+	case reflect.Slice:
+		return e.createSliceBuiltIn(rv)
+	case reflect.Struct:
+		if rv.Type() == builtInTimeType {
+			return e.writeExt(builtInTimeEncoder, rv)
+		}
+		return e.writeStruct(rv)
+	case reflect.Ptr:
+		if rv.IsNil() {
+			return e.writeNil()
+		}
+		return e.createBuiltIn(rv.Elem())
+	case reflect.Interface:
+		return e.createBuiltIn(rv.Elem())
+	default:
+		return e.createByKind(rv, kind)
 	}
 }
 
-func updateExtCoders() {
-	extCoders = make([]ext.StreamEncoder, len(extCoderMap))
-	i := 0
-	for k := range extCoderMap {
-		extCoders[i] = extCoderMap[k]
-		i++
+func (e *encoder) createSliceBuiltIn(rv reflect.Value) error {
+	if rv.IsNil() {
+		return e.writeNil()
 	}
+	l := rv.Len()
+	if e.isByteSlice(rv) {
+		if err := e.writeByteSliceLength(l); err != nil {
+			return err
+		}
+		return e.setBytes(rv.Bytes())
+	}
+	if err := e.writeSliceLength(l); err != nil {
+		return err
+	}
+	if find, err := e.writeFixedSlice(rv); err != nil {
+		return err
+	} else if find {
+		return nil
+	}
+
+	elementType := rv.Type().Elem()
+	if elementType.Kind() == reflect.Struct {
+		if elementType == builtInTimeType {
+			for i := 0; i < l; i++ {
+				if err := e.writeExt(builtInTimeEncoder, rv.Index(i)); err != nil {
+					return err
+				}
+			}
+			return nil
+		}
+		writeElement := e.getStructWriter(elementType)
+		for i := 0; i < l; i++ {
+			if err := writeElement(rv.Index(i)); err != nil {
+				return err
+			}
+		}
+		return nil
+	}
+
+	for i := 0; i < l; i++ {
+		if err := e.createBuiltIn(rv.Index(i)); err != nil {
+			return err
+		}
+	}
+	return nil
 }

--- a/internal/stream/encoding/ext_test.go
+++ b/internal/stream/encoding/ext_test.go
@@ -1,8 +1,10 @@
 package encoding
 
 import (
+	"reflect"
 	"testing"
 
+	"github.com/shamaton/msgpack/v3/ext"
 	tu "github.com/shamaton/msgpack/v3/internal/common/testutil"
 	"github.com/shamaton/msgpack/v3/time"
 )
@@ -10,13 +12,17 @@ import (
 func Test_AddExtEncoder(t *testing.T) {
 	t.Run("ignore", func(t *testing.T) {
 		AddExtEncoder(time.StreamEncoder)
-		tu.Equal(t, len(extCoders), 1)
+		coders := currentExtEncoderRegistry.Load().byKind[reflect.Struct]
+		tu.Equal(t, len(coders), 1)
+		tu.Equal(t, coders[time.StreamEncoder.Type()], ext.StreamEncoder(time.StreamEncoder))
 	})
 }
 
 func Test_RemoveExtEncoder(t *testing.T) {
 	t.Run("ignore", func(t *testing.T) {
 		RemoveExtEncoder(time.StreamEncoder)
-		tu.Equal(t, len(extCoders), 1)
+		coders := currentExtEncoderRegistry.Load().byKind[reflect.Struct]
+		tu.Equal(t, len(coders), 1)
+		tu.Equal(t, coders[time.StreamEncoder.Type()], ext.StreamEncoder(time.StreamEncoder))
 	})
 }

--- a/internal/stream/encoding/struct.go
+++ b/internal/stream/encoding/struct.go
@@ -6,7 +6,6 @@ import (
 	"sync"
 
 	"github.com/shamaton/msgpack/v3/def"
-	"github.com/shamaton/msgpack/v3/ext"
 	"github.com/shamaton/msgpack/v3/internal/common"
 )
 
@@ -60,16 +59,7 @@ func shouldOmitByParent(rv reflect.Value, omitPaths [][]int) bool {
 	return false
 }
 
-func (e *encoder) getStructWriter(typ reflect.Type) structWriteFunc {
-	for i := range extCoders {
-		if extCoders[i].Type() == typ {
-			return func(rv reflect.Value) error {
-				w := ext.CreateStreamWriter(e.w, e.buf)
-				return extCoders[i].Write(w, rv)
-			}
-		}
-	}
-
+func (e *encoder) getStructWriter(_ reflect.Type) structWriteFunc {
 	if e.asArray {
 		return e.writeStructArray
 	}
@@ -77,13 +67,6 @@ func (e *encoder) getStructWriter(typ reflect.Type) structWriteFunc {
 }
 
 func (e *encoder) writeStruct(rv reflect.Value) error {
-	for i := range extCoders {
-		if extCoders[i].Type() == rv.Type() {
-			w := ext.CreateStreamWriter(e.w, e.buf)
-			return extCoders[i].Write(w, rv)
-		}
-	}
-
 	if e.asArray {
 		return e.writeStructArray(rv)
 	}
@@ -120,6 +103,7 @@ func (e *encoder) writeStructArray(rv reflect.Value) error {
 			return err
 		}
 	}
+	noCustom := e.extRegistry.customCount == 0
 
 	if c.hasEmbedded {
 		for i := 0; i < num; i++ {
@@ -127,13 +111,25 @@ func (e *encoder) writeStructArray(rv reflect.Value) error {
 			if shouldOmitByParent(rv, c.omitPaths[i]) || !ok {
 				fieldValue = reflect.Value{}
 			}
-			if err := e.create(fieldValue); err != nil {
+			var err error
+			if noCustom {
+				err = e.createBuiltIn(fieldValue)
+			} else {
+				err = e.create(fieldValue)
+			}
+			if err != nil {
 				return err
 			}
 		}
 	} else {
 		for i := 0; i < num; i++ {
-			if err := e.create(rv.Field(c.simpleIndexes[i])); err != nil {
+			var err error
+			if noCustom {
+				err = e.createBuiltIn(rv.Field(c.simpleIndexes[i]))
+			} else {
+				err = e.create(rv.Field(c.simpleIndexes[i]))
+			}
+			if err != nil {
 				return err
 			}
 		}
@@ -185,6 +181,7 @@ func (e *encoder) writeStructMap(rv reflect.Value) error {
 			return err
 		}
 	}
+	noCustom := e.extRegistry.customCount == 0
 
 	if c.hasEmbedded {
 		num := len(c.indexes)
@@ -197,7 +194,13 @@ func (e *encoder) writeStructMap(rv reflect.Value) error {
 				if err := e.writeString(c.names[i]); err != nil {
 					return err
 				}
-				if err := e.create(fieldValue); err != nil {
+				var err error
+				if noCustom {
+					err = e.createBuiltIn(fieldValue)
+				} else {
+					err = e.create(fieldValue)
+				}
+				if err != nil {
 					return err
 				}
 			}
@@ -210,7 +213,13 @@ func (e *encoder) writeStructMap(rv reflect.Value) error {
 				if err := e.writeString(c.names[i]); err != nil {
 					return err
 				}
-				if err := e.create(fieldValue); err != nil {
+				var err error
+				if noCustom {
+					err = e.createBuiltIn(fieldValue)
+				} else {
+					err = e.create(fieldValue)
+				}
+				if err != nil {
 					return err
 				}
 			}

--- a/internal/stream/encoding/struct_test.go
+++ b/internal/stream/encoding/struct_test.go
@@ -16,6 +16,9 @@ func Test_writeStruct(t *testing.T) {
 	}
 
 	t.Run("Ext", func(t *testing.T) {
+		extMethod := func(e *encoder) func(reflect.Value) error {
+			return e.create
+		}
 		value := time.Time{}
 		testcases := AsXXXTestCases[time.Time]{
 			{
@@ -23,7 +26,7 @@ func Test_writeStruct(t *testing.T) {
 				Value:           value,
 				BufferSize:      1,
 				PreWriteSize:    1,
-				MethodForStruct: method,
+				MethodForStruct: extMethod,
 			},
 			{
 				Name:  "ok",
@@ -34,7 +37,7 @@ func Test_writeStruct(t *testing.T) {
 					0x00, 0x00, 0x00, 0x00, 0xff, 0xff, 0xff, 0xf1, 0x88, 0x6e, 0x09, 0x00,
 				},
 				BufferSize:      1,
-				MethodForStruct: method,
+				MethodForStruct: extMethod,
 			},
 		}
 		testcases.Run(t)

--- a/issue55_ext_test.go
+++ b/issue55_ext_test.go
@@ -132,3 +132,239 @@ func TestIssue55DefinedTypeExtThroughPublicAPIs(t *testing.T) {
 		})
 	}
 }
+
+// --- round-trip fixtures (encode AND decode) -------------------------------
+//
+// The types and coders above only exercise the encoder side (they assert
+// that the ext frame appears in the encoded bytes). The fixtures below prove
+// the full round trip: Unmarshal must restore a named non-struct type (and a
+// slice of it) from the ext frame that Marshal produced.
+
+const issue55RoundTripCode int8 = 43
+
+type issue55RoundTripStatus int
+
+const (
+	issue55RoundTripActive issue55RoundTripStatus = 1
+	issue55RoundTripClosed issue55RoundTripStatus = 2
+)
+
+type issue55RoundTripHolder struct {
+	Status   issue55RoundTripStatus
+	Statuses []issue55RoundTripStatus
+}
+
+type issue55RoundTripEncoder struct {
+	ext.EncoderCommon
+}
+
+func (*issue55RoundTripEncoder) Code() int8 { return issue55RoundTripCode }
+func (*issue55RoundTripEncoder) Type() reflect.Type {
+	return reflect.TypeOf(issue55RoundTripStatus(0))
+}
+func (*issue55RoundTripEncoder) CalcByteSize(reflect.Value) (int, error) {
+	return def.Byte1 + def.Byte1 + def.Byte1, nil
+}
+func (e *issue55RoundTripEncoder) WriteToBytes(value reflect.Value, offset int, data *[]byte) int {
+	offset = e.SetByte1Int(def.Fixext1, offset, data)
+	offset = e.SetByte1Int(int(e.Code()), offset, data)
+	return e.SetByte1Int64(value.Int(), offset, data)
+}
+
+type issue55RoundTripDecoder struct{}
+
+func (*issue55RoundTripDecoder) Code() int8 { return issue55RoundTripCode }
+func (*issue55RoundTripDecoder) IsType(offset int, data *[]byte) bool {
+	if (*data)[offset] != def.Fixext1 {
+		return false
+	}
+	return int8((*data)[offset+1]) == issue55RoundTripCode
+}
+func (*issue55RoundTripDecoder) AsValue(offset int, _ reflect.Kind, data *[]byte) (any, int, error) {
+	return issue55RoundTripStatus(int8((*data)[offset+2])), offset + 3, nil
+}
+
+// TestIssue55DefinedTypeExtRoundTrip proves the fix for shamaton/msgpack#55
+// end to end: registering an ext coder for a named non-struct type must
+// produce a lossless Marshal -> Unmarshal round trip, at the top level, as a
+// struct field, and inside a slice.
+func TestIssue55DefinedTypeExtRoundTrip(t *testing.T) {
+	encoder := &issue55RoundTripEncoder{}
+	decoder := &issue55RoundTripDecoder{}
+	if err := msgpack.AddExtCoder(encoder, decoder); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() {
+		if err := msgpack.RemoveExtCoder(encoder, decoder); err != nil {
+			t.Error(err)
+		}
+	})
+
+	t.Run("top level", func(t *testing.T) {
+		b, err := msgpack.Marshal(issue55RoundTripActive)
+		if err != nil {
+			t.Fatal(err)
+		}
+		want := []byte{def.Fixext1, byte(issue55RoundTripCode), byte(issue55RoundTripActive)}
+		if !bytes.Equal(b, want) {
+			t.Fatalf("encode mismatch. got % 02x, want % 02x", b, want)
+		}
+
+		var got issue55RoundTripStatus
+		if err := msgpack.Unmarshal(b, &got); err != nil {
+			t.Fatalf("decode failed: %v", err)
+		}
+		if got != issue55RoundTripActive {
+			t.Fatalf("round-trip mismatch. got %d, want %d", got, issue55RoundTripActive)
+		}
+	})
+
+	t.Run("slice", func(t *testing.T) {
+		in := []issue55RoundTripStatus{issue55RoundTripActive, issue55RoundTripClosed}
+		b, err := msgpack.Marshal(in)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		var got []issue55RoundTripStatus
+		if err := msgpack.Unmarshal(b, &got); err != nil {
+			t.Fatalf("decode failed: %v", err)
+		}
+		if !reflect.DeepEqual(got, in) {
+			t.Fatalf("round-trip mismatch. got %v, want %v", got, in)
+		}
+	})
+
+	t.Run("struct field and slice field", func(t *testing.T) {
+		in := issue55RoundTripHolder{
+			Status:   issue55RoundTripClosed,
+			Statuses: []issue55RoundTripStatus{issue55RoundTripActive, issue55RoundTripClosed},
+		}
+		b, err := msgpack.Marshal(in)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		var got issue55RoundTripHolder
+		if err := msgpack.Unmarshal(b, &got); err != nil {
+			t.Fatalf("decode failed: %v", err)
+		}
+		if !reflect.DeepEqual(got, in) {
+			t.Fatalf("round-trip mismatch. got %+v, want %+v", got, in)
+		}
+	})
+}
+
+// --- stream round-trip fixtures (encode AND decode via io.Writer/io.Reader) -
+
+const issue55StreamRoundTripCode int8 = 45
+
+type issue55StreamRoundTripStatus int
+
+const (
+	issue55StreamRoundTripActive issue55StreamRoundTripStatus = 1
+	issue55StreamRoundTripClosed issue55StreamRoundTripStatus = 2
+)
+
+type issue55StreamRoundTripHolder struct {
+	Status   issue55StreamRoundTripStatus
+	Statuses []issue55StreamRoundTripStatus
+}
+
+type issue55StreamRoundTripEncoder struct{}
+
+func (*issue55StreamRoundTripEncoder) Code() int8 { return issue55StreamRoundTripCode }
+func (*issue55StreamRoundTripEncoder) Type() reflect.Type {
+	return reflect.TypeOf(issue55StreamRoundTripStatus(0))
+}
+func (e *issue55StreamRoundTripEncoder) Write(w ext.StreamWriter, value reflect.Value) error {
+	if err := w.WriteByte1Int(def.Fixext1); err != nil {
+		return err
+	}
+	if err := w.WriteByte1Int(int(e.Code())); err != nil {
+		return err
+	}
+	return w.WriteByte1Int64(value.Int())
+}
+
+type issue55StreamRoundTripDecoder struct{}
+
+func (*issue55StreamRoundTripDecoder) Code() int8 { return issue55StreamRoundTripCode }
+func (*issue55StreamRoundTripDecoder) IsType(code byte, innerType int8, _ int) bool {
+	return code == def.Fixext1 && innerType == issue55StreamRoundTripCode
+}
+func (*issue55StreamRoundTripDecoder) ToValue(_ byte, data []byte, _ reflect.Kind) (any, error) {
+	return issue55StreamRoundTripStatus(int8(data[0])), nil
+}
+
+// TestIssue55DefinedTypeExtStreamRoundTrip proves the fix for
+// shamaton/msgpack#55 through the streaming public APIs: registering a
+// stream ext coder for a named non-struct type must produce a lossless
+// MarshalWrite -> UnmarshalRead round trip, at the top level, as a struct
+// field, and inside a slice -- not just through the byte-slice Marshal API.
+func TestIssue55DefinedTypeExtStreamRoundTrip(t *testing.T) {
+	encoder := &issue55StreamRoundTripEncoder{}
+	decoder := &issue55StreamRoundTripDecoder{}
+	if err := msgpack.AddExtStreamCoder(encoder, decoder); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() {
+		if err := msgpack.RemoveExtStreamCoder(encoder, decoder); err != nil {
+			t.Error(err)
+		}
+	})
+
+	t.Run("top level", func(t *testing.T) {
+		var buf bytes.Buffer
+		if err := msgpack.MarshalWrite(&buf, issue55StreamRoundTripActive); err != nil {
+			t.Fatal(err)
+		}
+		want := []byte{def.Fixext1, byte(issue55StreamRoundTripCode), byte(issue55StreamRoundTripActive)}
+		if !bytes.Equal(buf.Bytes(), want) {
+			t.Fatalf("encode mismatch. got % 02x, want % 02x", buf.Bytes(), want)
+		}
+
+		var got issue55StreamRoundTripStatus
+		if err := msgpack.UnmarshalRead(&buf, &got); err != nil {
+			t.Fatalf("decode failed: %v", err)
+		}
+		if got != issue55StreamRoundTripActive {
+			t.Fatalf("round-trip mismatch. got %d, want %d", got, issue55StreamRoundTripActive)
+		}
+	})
+
+	t.Run("slice", func(t *testing.T) {
+		in := []issue55StreamRoundTripStatus{issue55StreamRoundTripActive, issue55StreamRoundTripClosed}
+		var buf bytes.Buffer
+		if err := msgpack.MarshalWrite(&buf, in); err != nil {
+			t.Fatal(err)
+		}
+
+		var got []issue55StreamRoundTripStatus
+		if err := msgpack.UnmarshalRead(&buf, &got); err != nil {
+			t.Fatalf("decode failed: %v", err)
+		}
+		if !reflect.DeepEqual(got, in) {
+			t.Fatalf("round-trip mismatch. got %v, want %v", got, in)
+		}
+	})
+
+	t.Run("struct field and slice field", func(t *testing.T) {
+		in := issue55StreamRoundTripHolder{
+			Status:   issue55StreamRoundTripClosed,
+			Statuses: []issue55StreamRoundTripStatus{issue55StreamRoundTripActive, issue55StreamRoundTripClosed},
+		}
+		var buf bytes.Buffer
+		if err := msgpack.MarshalWrite(&buf, in); err != nil {
+			t.Fatal(err)
+		}
+
+		var got issue55StreamRoundTripHolder
+		if err := msgpack.UnmarshalRead(&buf, &got); err != nil {
+			t.Fatalf("decode failed: %v", err)
+		}
+		if !reflect.DeepEqual(got, in) {
+			t.Fatalf("round-trip mismatch. got %+v, want %+v", got, in)
+		}
+	})
+}

--- a/issue55_ext_test.go
+++ b/issue55_ext_test.go
@@ -1,0 +1,134 @@
+package msgpack_test
+
+import (
+	"bytes"
+	"reflect"
+	"testing"
+
+	"github.com/shamaton/msgpack/v3"
+	"github.com/shamaton/msgpack/v3/def"
+	"github.com/shamaton/msgpack/v3/ext"
+)
+
+const issue55PublicCode int8 = 40
+
+type issue55PublicStatus int
+
+type issue55PublicHolder struct {
+	Status issue55PublicStatus
+}
+
+type issue55PublicEncoder struct {
+	ext.EncoderCommon
+}
+
+func (*issue55PublicEncoder) Code() int8         { return issue55PublicCode }
+func (*issue55PublicEncoder) Type() reflect.Type { return reflect.TypeOf(issue55PublicStatus(0)) }
+func (*issue55PublicEncoder) CalcByteSize(reflect.Value) (int, error) {
+	return 3, nil
+}
+func (e *issue55PublicEncoder) WriteToBytes(_ reflect.Value, offset int, data *[]byte) int {
+	offset = e.SetByte1Int(def.Fixext1, offset, data)
+	offset = e.SetByte1Int(int(e.Code()), offset, data)
+	return e.SetByte1Uint64(0xaa, offset, data)
+}
+
+type issue55PublicDecoder struct{}
+
+func (*issue55PublicDecoder) Code() int8               { return issue55PublicCode }
+func (*issue55PublicDecoder) IsType(int, *[]byte) bool { return false }
+func (*issue55PublicDecoder) AsValue(int, reflect.Kind, *[]byte) (any, int, error) {
+	return nil, 0, nil
+}
+
+type issue55PublicStreamEncoder struct{}
+
+func (*issue55PublicStreamEncoder) Code() int8         { return issue55PublicCode }
+func (*issue55PublicStreamEncoder) Type() reflect.Type { return reflect.TypeOf(issue55PublicStatus(0)) }
+func (e *issue55PublicStreamEncoder) Write(w ext.StreamWriter, _ reflect.Value) error {
+	if err := w.WriteByte1Int(def.Fixext1); err != nil {
+		return err
+	}
+	if err := w.WriteByte1Int(int(e.Code())); err != nil {
+		return err
+	}
+	return w.WriteByte1Uint64(0xaa)
+}
+
+type issue55PublicStreamDecoder struct{}
+
+func (*issue55PublicStreamDecoder) Code() int8 { return issue55PublicCode }
+func (*issue55PublicStreamDecoder) IsType(byte, int8, int) bool {
+	return false
+}
+func (*issue55PublicStreamDecoder) ToValue(byte, []byte, reflect.Kind) (any, error) {
+	return nil, nil
+}
+
+func TestIssue55DefinedTypeExtThroughPublicAPIs(t *testing.T) {
+	encoder := &issue55PublicEncoder{}
+	decoder := &issue55PublicDecoder{}
+	if err := msgpack.AddExtCoder(encoder, decoder); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() {
+		if err := msgpack.RemoveExtCoder(encoder, decoder); err != nil {
+			t.Error(err)
+		}
+	})
+
+	streamEncoder := &issue55PublicStreamEncoder{}
+	streamDecoder := &issue55PublicStreamDecoder{}
+	if err := msgpack.AddExtStreamCoder(streamEncoder, streamDecoder); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() {
+		if err := msgpack.RemoveExtStreamCoder(streamEncoder, streamDecoder); err != nil {
+			t.Error(err)
+		}
+	})
+
+	extValue := []byte{def.Fixext1, byte(issue55PublicCode), 0xaa}
+	value := issue55PublicHolder{Status: 1}
+	marshalCases := []struct {
+		name string
+		fn   func(any) ([]byte, error)
+	}{
+		{name: "map", fn: msgpack.MarshalAsMap},
+		{name: "array", fn: msgpack.MarshalAsArray},
+	}
+	for _, tc := range marshalCases {
+		t.Run("marshal "+tc.name, func(t *testing.T) {
+			encoded, err := tc.fn(value)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if !bytes.Contains(encoded, extValue) {
+				t.Fatalf("defined type extension not found in %x", encoded)
+			}
+		})
+	}
+
+	streamCases := []struct {
+		name string
+		fn   func(*bytes.Buffer, any) error
+	}{
+		{name: "map", fn: func(buffer *bytes.Buffer, value any) error {
+			return msgpack.MarshalWriteAsMap(buffer, value)
+		}},
+		{name: "array", fn: func(buffer *bytes.Buffer, value any) error {
+			return msgpack.MarshalWriteAsArray(buffer, value)
+		}},
+	}
+	for _, tc := range streamCases {
+		t.Run("stream "+tc.name, func(t *testing.T) {
+			var buffer bytes.Buffer
+			if err := tc.fn(&buffer, value); err != nil {
+				t.Fatal(err)
+			}
+			if !bytes.Contains(buffer.Bytes(), extValue) {
+				t.Fatalf("defined type extension not found in %x", buffer.Bytes())
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary
* Fix ext coders registered for named non-struct types (e.g. Go "enum" types like `type Role uint8`) being silently ignored outside the struct dispatch path, on both `Marshal`/`Unmarshal` and the streaming `Encoder`/`Decoder` APIs.
* Applies to top-level values, slice elements, and struct fields.
* Adds round-trip tests and benchmarks for all four combinations (encode/decode × non-stream/stream).

## Background / Motivation
The ext registry (`AddExtCoder`/`AddExtEncoder`) accepts any `reflect.Type`, but was only consulted from the struct dispatch (`calcStruct`/`writeStruct` on encode, `setStruct` on decode). The general dispatch functions (`calcSize`/`create` on encode, `decode` on decode) switch purely on `reflect.Kind`, so an ext coder registered for a named non-struct type was silently dropped at the top level and inside slices — `Marshal` fell back to the plain kind encoding and `Unmarshal` couldn't recover the value, making the round-trip lossy. The same gap existed in the streaming API, which shares none of this dispatch code with the non-streaming path.

Credit: originally reported and root-caused by @youdie006 in #110 (repro, root-cause analysis, and an initial encode-side fix for the non-stream API). This PR takes a different implementation approach to also cover decode, the streaming API, and avoid a performance regression on the non-ext hot path (see below) — closing #110 with thanks for the report.

## Changes
* `internal/encoding`: kind-partitioned ext encoder registry (`atomic.Pointer` + copy-on-write update) so `calcSize`/`create` only consult ext coders for kinds that actually have one registered, instead of scanning all registered coders for every value.
* `internal/decoding`: new `tryExtDecode` helper, used from both `decode()` and `setStruct`, that recognizes ext wire frames via `extEndOffset` (full boundary validation, so truncated ext frames are still rejected before any custom decoder runs) and dispatches to the first registered decoder whose Go type matches the destination.
* `internal/stream/encoding`, `internal/stream/decoding`: mirror the same designs for the streaming API.

## Testing
* `go test ./...`, `go vet ./...`, `go build ./...` all clean; race detector clean on the new stream decode tests.
* New round-trip tests: `issue55_ext_test.go` (public API, non-stream + stream), plus package-level tests in `internal/encoding`, `internal/decoding`, `internal/stream/encoding`, `internal/stream/decoding`.
* Benchmarks added under `internal/encoding` and `internal/decoding` comparing plain-value and ext-slice encode/decode paths.

Closes #55.